### PR TITLE
Updated required version of property-access

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.3.0",
         "coduo/php-to-string": "0.1.*",
-        "symfony/property-access": "~2.3",
+        "symfony/property-access": "~2.4",
         "symfony/expression-language": "~2.4"
     },
     "require-dev": {


### PR DESCRIPTION
Library is using method `Symfony\Component\PropertyAccess\PropertyAccessorBuilder::enableExceptionOnInvalidIndex()` which is unavailable in symfony/property-access 2.3
http://api.symfony.com/2.3/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.html

So I bumped reqiored version of this component to 2.4
