### PR TITLE
A null value can be matched.

### DIFF
--- a/match.php
+++ b/match.php
@@ -5,6 +5,7 @@ use Coduo\PHPMatcher\Matcher\CallbackMatcher;
 use Coduo\PHPMatcher\Matcher\ChainMatcher;
 use Coduo\PHPMatcher\Matcher\ExpressionMatcher;
 use Coduo\PHPMatcher\Matcher\JsonMatcher;
+use Coduo\PHPMatcher\Matcher\NullMatcher;
 use Coduo\PHPMatcher\Matcher\ScalarMatcher;
 use Coduo\PHPMatcher\Matcher\TypeMatcher;
 use Coduo\PHPMatcher\Matcher\WildcardMatcher;
@@ -36,6 +37,7 @@ if (!function_exists('match')) {
             new CallbackMatcher(),
             new ExpressionMatcher(),
             new TypeMatcher(),
+            new NullMatcher(),
             new ScalarMatcher(),
             new WildcardMatcher()
         ));

--- a/src/Coduo/PHPMatcher/Matcher/JsonMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/JsonMatcher.php
@@ -4,7 +4,7 @@ namespace Coduo\PHPMatcher\Matcher;
 
 class JsonMatcher extends Matcher
 {
-    const TRANSFORM_QUOTATION_PATTERN = '/([^"])@(integer|string|array|double|wildcard|boolean)@([^"])/';
+    const TRANSFORM_QUOTATION_PATTERN = '/([^"])@(integer|string|array|double|wildcard|boolean|null)@([^"])/';
     const TRANSFORM_QUOTATION_REPLACEMENT = '$1"@$2@"$3';
 
     /**

--- a/src/Coduo/PHPMatcher/Matcher/NullMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/NullMatcher.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher;
+
+use Coduo\ToString\String;
+
+class NullMatcher extends Matcher
+{
+    const MATCH_PATTERN = "/^@null@$/";
+
+    /**
+     * {@inheritDoc}
+     */
+    public function match($value, $pattern)
+    {
+        if (null !== $value) {
+            $this->error = sprintf("%s \"%s\" does not match null.", gettype($value), new String($value));
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function canMatch($pattern)
+    {
+        return is_string($pattern) && 0 !== preg_match(self::MATCH_PATTERN, $pattern);
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/JsonMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/JsonMatcherTest.php
@@ -4,6 +4,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Matcher\ArrayMatcher;
 use Coduo\PHPMatcher\Matcher\ChainMatcher;
 use Coduo\PHPMatcher\Matcher\JsonMatcher;
+use Coduo\PHPMatcher\Matcher\NullMatcher;
 use Coduo\PHPMatcher\Matcher\ScalarMatcher;
 use Coduo\PHPMatcher\Matcher\TypeMatcher;
 use Coduo\PHPMatcher\Matcher\WildcardMatcher;
@@ -20,6 +21,7 @@ class JsonMatcherTest extends \PHPUnit_Framework_TestCase
         $scalarMatchers = new ChainMatcher(array(
             new TypeMatcher(),
             new ScalarMatcher(),
+            new NullMatcher(),
             new WildcardMatcher()
         ));
         $this->matcher = new JsonMatcher(new ChainMatcher(array(
@@ -130,6 +132,10 @@ class JsonMatcherTest extends \PHPUnit_Framework_TestCase
             array(
                 '{"foobar":[1.22, 2, "hello"]}',
                 '{"foobar":[@double@, @integer@, @string@]}'
+            ),
+            array(
+                '{"null":[null]}',
+                '{"null":[@null@]}'
             ),
             array(
                 '{"users":[{"firstName":"Norbert","lastName":"Orzechowicz","roles":["ROLE_USER", "ROLE_DEVELOPER"]}]}',

--- a/tests/Coduo/PHPMatcher/Matcher/NullMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/NullMatcherTest.php
@@ -1,0 +1,95 @@
+<?php
+namespace Coduo\PHPMatcher\Tests\Matcher;
+
+use Coduo\PHPMatcher\Matcher\NullMatcher;
+
+class NullMatcherTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider positiveCanMatchData
+     */
+    public function test_positive_can_matches($pattern)
+    {
+        $matcher = new NullMatcher();
+        $this->assertTrue($matcher->canMatch($pattern));
+    }
+
+    /**
+     * @dataProvider negativeCanMatchData
+     */
+    public function test_negative_can_matches($pattern)
+    {
+        $matcher = new NullMatcher();
+        $this->assertFalse($matcher->canMatch($pattern));
+    }
+
+    /**
+     * @dataProvider positiveMatchData
+     */
+    public function test_positive_match($value, $pattern)
+    {
+        $matcher = new NullMatcher();
+        $this->assertTrue($matcher->match($value, $pattern));
+    }
+
+    /**
+     * @dataProvider negativeMatchData
+     */
+    public function test_negative_match($value, $pattern)
+    {
+        $matcher = new NullMatcher();
+        $this->assertFalse($matcher->match($value, $pattern));
+    }
+
+    /**
+     * @dataProvider negativeMatchDescription
+     */
+    public function test_negative_match_description($value, $pattern, $error)
+    {
+        $matcher = new NullMatcher();
+        $matcher->match($value, $pattern);
+        $this->assertEquals($error, $matcher->getError());
+    }
+
+    public static function positiveCanMatchData()
+    {
+        return array(
+            array("@null@")
+        );
+    }
+
+    public static function positiveMatchData()
+    {
+        return array(
+            array(null, "@null@"),
+        );
+    }
+
+    public static function negativeCanMatchData()
+    {
+        return array(
+            array("@null"),
+            array("null"),
+            array(0)
+        );
+    }
+
+    public static function negativeMatchData()
+    {
+        return array(
+            array("null", "@null@"),
+            array(0,  "@null@")
+        );
+    }
+
+    public static function negativeMatchDescription()
+    {
+        return array(
+            array("test", "@boolean@", "string \"test\" does not match null."),
+            array(new \stdClass,  "@string@", "object \"\\stdClass\" does not match null."),
+            array(1.1, "@integer@", "double \"1.1\" does not match null."),
+            array(false, "@double@", "boolean \"false\" does not match null."),
+            array(1, "@array@", "integer \"1\" does not match null.")
+        );
+    }
+}


### PR DESCRIPTION
Hi there,

When testing my JSON OAuth responses, I tried to compare with the following pattern;

``` json
{
    "access_token": @string@,
    "expires_in": 3600,
    "token_type": "bearer",
    "scope": null,
    "refresh_token": @string@
}
```

Which gave me the error `There is no element under path [scope] in pattern.`.

To fix this, I came up with a NullMatcher so that the following pattern can be used;

``` json
{
    "access_token": @string@,
    "expires_in": 3600,
    "token_type": "bearer",
    "scope": @null@,
    "refresh_token": @string@
}
```
