### PR TITLE
Pattern expander mechanism 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": ">=5.3.0",
         "coduo/php-to-string": "~1.0",
         "symfony/property-access": "~2.3",
-        "symfony/expression-language": "~2.4"
+        "symfony/expression-language": "~2.4",
+        "doctrine/lexer": "1.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/src/Coduo/PHPMatcher/AST/Expander.php
+++ b/src/Coduo/PHPMatcher/AST/Expander.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Coduo\PHPMatcher\AST;
+
+class Expander implements Node
+{
+    /**
+     * @var
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $arguments;
+
+    /**
+     * @param $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->arguments = array();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param $argument
+     */
+    public function addArgument($argument)
+    {
+        $this->arguments[] = $argument;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasArguments()
+    {
+        return (boolean) count($this->arguments);
+    }
+
+    /**
+     * @return array
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+}

--- a/src/Coduo/PHPMatcher/AST/Node.php
+++ b/src/Coduo/PHPMatcher/AST/Node.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Coduo\PHPMatcher\AST;
+
+interface Node
+{
+
+}

--- a/src/Coduo/PHPMatcher/AST/Pattern.php
+++ b/src/Coduo/PHPMatcher/AST/Pattern.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Coduo\PHPMatcher\AST;
+
+class Pattern implements Node
+{
+    /**
+     * @var Type
+     */
+    private $type;
+
+    /**
+     * @var Expander[]|array
+     */
+    private $expanders;
+
+    /**
+     * @param Type $type
+     */
+    public function __construct(Type $type)
+    {
+        $this->expanders = array();
+        $this->type = $type;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasExpanders()
+    {
+        return (boolean) count($this->expanders);
+    }
+
+    /**
+     * @return Expander[]|array
+     */
+    public function getExpanders()
+    {
+        return $this->expanders;
+    }
+
+    /**
+     * @param Expander $expander
+     */
+    public function addExpander(Expander $expander)
+    {
+        $this->expanders[] = $expander;
+    }
+}

--- a/src/Coduo/PHPMatcher/AST/Type.php
+++ b/src/Coduo/PHPMatcher/AST/Type.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Coduo\PHPMatcher\AST;
+
+class Type implements Node
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @param string $type
+     */
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    public function __toString()
+    {
+        return $this->type;
+    }
+}

--- a/src/Coduo/PHPMatcher/Exception/Exception.php
+++ b/src/Coduo/PHPMatcher/Exception/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Coduo\PHPMatcher\Exception;
+
+class Exception extends \Exception
+{
+}

--- a/src/Coduo/PHPMatcher/Exception/InvalidExpanderTypeException.php
+++ b/src/Coduo/PHPMatcher/Exception/InvalidExpanderTypeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Coduo\PHPMatcher\Exception;
+
+class InvalidExpanderTypeException extends Exception
+{
+}

--- a/src/Coduo/PHPMatcher/Exception/PatternException.php
+++ b/src/Coduo/PHPMatcher/Exception/PatternException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Coduo\PHPMatcher\Exception;
+
+class PatternException extends Exception
+{
+    public static function syntaxError($message, $previous = null)
+    {
+        return new self('[Syntax Error] ' . $message, 0, $previous);
+    }
+}

--- a/src/Coduo/PHPMatcher/Exception/UnknownExpanderClassException.php
+++ b/src/Coduo/PHPMatcher/Exception/UnknownExpanderClassException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Coduo\PHPMatcher\Exception;
+
+class UnknownExpanderClassException extends Exception
+{
+}

--- a/src/Coduo/PHPMatcher/Exception/UnknownExpanderException.php
+++ b/src/Coduo/PHPMatcher/Exception/UnknownExpanderException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Coduo\PHPMatcher\Exception;
+
+class UnknownExpanderException extends Exception
+{
+}

--- a/src/Coduo/PHPMatcher/Factory.php
+++ b/src/Coduo/PHPMatcher/Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Coduo\PHPMatcher;
 
 interface Factory

--- a/src/Coduo/PHPMatcher/Factory/SimpleFactory.php
+++ b/src/Coduo/PHPMatcher/Factory/SimpleFactory.php
@@ -3,7 +3,9 @@
 namespace Coduo\PHPMatcher\Factory;
 
 use Coduo\PHPMatcher\Factory;
+use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Parser;
 
 class SimpleFactory implements Factory
 {
@@ -21,7 +23,7 @@ class SimpleFactory implements Factory
     protected function buildMatchers()
     {
         $scalarMatchers = $this->buildScalarMatchers();
-        $arrayMatcher = new Matcher\ArrayMatcher($scalarMatchers);
+        $arrayMatcher = new Matcher\ArrayMatcher($scalarMatchers, $this->buildParser());
 
         return new Matcher\ChainMatcher(array(
             $scalarMatchers,
@@ -35,17 +37,27 @@ class SimpleFactory implements Factory
      */
     protected function buildScalarMatchers()
     {
+        $parser = $this->buildParser();
+
         return new Matcher\ChainMatcher(array(
             new Matcher\CallbackMatcher(),
             new Matcher\ExpressionMatcher(),
             new Matcher\NullMatcher(),
-            new Matcher\StringMatcher(),
-            new Matcher\IntegerMatcher(),
+            new Matcher\StringMatcher($parser),
+            new Matcher\IntegerMatcher($parser),
             new Matcher\BooleanMatcher(),
-            new Matcher\DoubleMatcher(),
+            new Matcher\DoubleMatcher($parser),
             new Matcher\NumberMatcher(),
             new Matcher\ScalarMatcher(),
             new Matcher\WildcardMatcher()
         ));
+    }
+
+    /**
+     * @return Parser
+     */
+    protected function buildParser()
+    {
+        return new Parser(new Lexer());
     }
 }

--- a/src/Coduo/PHPMatcher/Lexer.php
+++ b/src/Coduo/PHPMatcher/Lexer.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Coduo\PHPMatcher;
+
+use Doctrine\Common\Lexer\AbstractLexer;
+
+class Lexer extends AbstractLexer
+{
+    const T_NONE = 1;
+    const T_EXPANDER_NAME = 2;
+    const T_CLOSE_PARENTHESIS = 3;
+    const T_OPEN_CURLY_BRACE    = 4;
+    const T_CLOSE_CURLY_BRACE   = 5;
+    const T_STRING = 6;
+    const T_NUMBER = 7;
+    const T_BOOLEAN = 8;
+    const T_NULL = 9;
+    const T_COMMA  = 10;
+    const T_COLON = 11;
+    const T_TYPE_PATTERN = 12;
+
+    /**
+     * Lexical catchable patterns.
+     *
+     * @return array
+     */
+    protected function getCatchablePatterns()
+    {
+        return array(
+            "\\.?[a-zA-Z0-9_]+\\(", // expander name
+            "[a-zA-Z0-9.]*", // words
+            "\\-?[0-9]*\\.?[0-9]*", // numbers
+            "'(?:[^']|'')*'", // string between ' character
+            "\"(?:[^\"]|\"\")*\"", // string between " character,
+            "@[a-zA-Z0-9\\*]+@", // type pattern
+        );
+    }
+
+    /**
+     * Lexical non-catchable patterns.
+     *
+     * @return array
+     */
+    protected function getNonCatchablePatterns()
+    {
+        return array(
+            "\\s+",
+        );
+    }
+
+    /**
+     * Retrieve token type. Also processes the token value if necessary.
+     *
+     * @param string $value
+     * @return integer
+     */
+    protected function getType(&$value)
+    {
+        switch($value) {
+            case ')':
+                return self::T_CLOSE_PARENTHESIS;
+            case '{':
+                return self::T_OPEN_CURLY_BRACE;
+            case '}':
+                return self::T_CLOSE_CURLY_BRACE;
+            case ':':
+                return self::T_COLON;
+            case ',':
+                return self::T_COMMA;
+            default:
+                $type = self::T_NONE;
+                break;
+        }
+
+        if ($this->isTypePatternToken($value)) {
+            $value = trim($value, '@');
+            return self::T_TYPE_PATTERN;
+        }
+
+        if ($this->isStringToken($value)) {
+            $value = $this->extractStringValue($value);
+            return self::T_STRING;
+        }
+
+        if ($this->isBooleanToken($value)) {
+            $value = (strtolower($value) === 'true') ? true : false;
+            return self::T_BOOLEAN;
+        }
+
+        if ($this->isNullToken($value)) {
+            $value = null;
+            return self::T_NULL;
+        }
+
+        if (is_numeric($value)) {
+            if (is_string($value)) {
+                $value = (strpos($value, '.') === false) ? (int) $value : (float) $value;
+            }
+
+            return self::T_NUMBER;
+        }
+
+        if ($this->isExpanderNameToken($value)) {
+            $value = rtrim(ltrim($value, '.'), '(');
+            return self::T_EXPANDER_NAME;
+        }
+
+        return $type;
+    }
+
+    /**
+     * @param $value
+     * @return bool
+     */
+    protected function isStringToken($value)
+    {
+        return in_array(substr($value, 0, 1), array("\"", "'"));
+    }
+
+    /**
+     * @param string $value
+     * @return bool
+     */
+    protected function isBooleanToken($value)
+    {
+        return in_array(strtolower($value), array('true', 'false'), true);
+    }
+
+    /**
+     * @param string $value
+     * @return bool
+     */
+    protected function isNullToken($value)
+    {
+        return strtolower($value) === 'null';
+    }
+
+    /**
+     * @param $value
+     * @return string
+     */
+    protected function extractStringValue($value)
+    {
+        return trim(trim($value, "'"), '"');
+    }
+
+    /**
+     * @param $value
+     * @return bool
+     */
+    protected function isExpanderNameToken($value)
+    {
+        return substr($value, -1) === '(' && strlen($value) > 1;
+    }
+
+    /**
+     * @param $value
+     * @return bool
+     */
+    protected function isTypePatternToken($value)
+    {
+        return substr($value, 0, 1) === '@' && substr($value, strlen($value) - 1, 1) === '@' && strlen($value) > 1;
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher.php
+++ b/src/Coduo/PHPMatcher/Matcher.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Coduo\PHPMatcher;
 
 use Coduo\PHPMatcher\Matcher\ValueMatcher;

--- a/src/Coduo/PHPMatcher/Matcher/DoubleMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/DoubleMatcher.php
@@ -2,11 +2,23 @@
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Parser;
 use Coduo\ToString\String;
 
 class DoubleMatcher extends Matcher
 {
-    const DOUBLE_PATTERN = '/^@double@$/';
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    /**
+     * @param Parser $parser
+     */
+    public function __construct(Parser $parser)
+    {
+        $this->parser = $parser;
+    }
 
     /**
      * {@inheritDoc}
@@ -18,6 +30,12 @@ class DoubleMatcher extends Matcher
             return false;
         }
 
+        $typePattern = $this->parser->parse($pattern);
+        if (!$typePattern->matchExpanders($value)) {
+            $this->error = $typePattern->getError();
+            return false;
+        }
+
         return true;
     }
 
@@ -26,6 +44,10 @@ class DoubleMatcher extends Matcher
      */
     public function canMatch($pattern)
     {
-        return is_string($pattern) && 0 !== preg_match(self::DOUBLE_PATTERN, $pattern);
+        if (!is_string($pattern)) {
+            return false;
+        }
+
+        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is('double');
     }
 }

--- a/src/Coduo/PHPMatcher/Matcher/IntegerMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/IntegerMatcher.php
@@ -2,11 +2,23 @@
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Parser;
 use Coduo\ToString\String;
 
 class IntegerMatcher extends Matcher
 {
-    const INTEGER_PATTERN = '/^@integer@$/';
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    /**
+     * @param Parser $parser
+     */
+    public function __construct(Parser $parser)
+    {
+        $this->parser = $parser;
+    }
 
     /**
      * {@inheritDoc}
@@ -18,6 +30,12 @@ class IntegerMatcher extends Matcher
             return false;
         }
 
+        $typePattern = $this->parser->parse($pattern);
+        if (!$typePattern->matchExpanders($value)) {
+            $this->error = $typePattern->getError();
+            return false;
+        }
+
         return true;
     }
 
@@ -26,6 +44,10 @@ class IntegerMatcher extends Matcher
      */
     public function canMatch($pattern)
     {
-        return is_string($pattern) && 0 !== preg_match(self::INTEGER_PATTERN, $pattern);
+        if (!is_string($pattern)) {
+            return false;
+        }
+
+        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is('integer');
     }
 }

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/Contains.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/Contains.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\ToString\String;
+
+class Contains implements PatternExpander
+{
+    /**
+     * @var null|string
+     */
+    private $error;
+
+    /**
+     * @var
+     */
+    private $string;
+
+    /**
+     * @var bool
+     */
+    private $ignoreCase;
+
+    /**
+     * @param $string
+     * @param bool $ignoreCase
+     */
+    public function __construct($string, $ignoreCase = false)
+    {
+        $this->string = $string;
+        $this->ignoreCase = $ignoreCase;
+    }
+
+    /**
+     * @param $value
+     * @return boolean
+     */
+    public function match($value)
+    {
+        if (!is_string($value)) {
+            $this->error = sprintf("Contains expander require \"string\", got \"%s\".", new String($value));
+            return false;
+        }
+
+        $contains = $this->ignoreCase
+            ? mb_strpos(mb_strtolower($value), mb_strtolower($this->string))
+            : mb_strpos($value, $this->string);
+
+        if ($contains === false) {
+            $this->error = sprintf("String \"%s\" doesn't contains \"%s\".", $value, $this->string);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/EndsWith.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/EndsWith.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\ToString\String;
+
+class EndsWith implements PatternExpander
+{
+    /**
+     * @var
+     */
+    private $stringEnding;
+
+    /**
+     * @var null|string
+     */
+    private $error;
+
+    /**
+     * @var bool
+     */
+    private $ignoreCase;
+
+    /**
+     * @param string $stringEnding
+     * @param bool $ignoreCase
+     */
+    public function __construct($stringEnding, $ignoreCase = false)
+    {
+        if (!is_string($stringEnding)) {
+            throw new \InvalidArgumentException("String ending must be a valid string.");
+        }
+        
+        $this->stringEnding = $stringEnding;
+        $this->ignoreCase = $ignoreCase;
+    }
+
+    /**
+     * @param $value
+     * @return boolean
+     */
+    public function match($value)
+    {
+        if (!is_string($value)) {
+            $this->error = sprintf("EndsWith expander require \"string\", got \"%s\".", new String($value));
+            return false;
+        }
+
+        if (empty($this->stringEnding)) {
+            return true;
+        }
+
+        if (!$this->matchValue($value)) {
+            $this->error = sprintf("string \"%s\" doesn't ends with string \"%s\".", $value, $this->stringEnding);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * @param $value
+     * @return bool
+     */
+    protected function matchValue($value)
+    {
+        return $this->ignoreCase
+            ? mb_substr(mb_strtolower($value), -mb_strlen(mb_strtolower($this->stringEnding))) === mb_strtolower($this->stringEnding)
+            : mb_substr($value, -mb_strlen($this->stringEnding)) === $this->stringEnding;
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/GreaterThan.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/GreaterThan.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\ToString\String;
+
+class GreaterThan implements PatternExpander
+{
+    /**
+     * @var
+     */
+    private $boundary;
+
+    /**
+     * @var null|string
+     */
+    private $error;
+
+    /**
+     * @param $boundary
+     */
+    public function __construct($boundary)
+    {
+        if (!is_float($boundary) && !is_integer($boundary) && !is_double($boundary)) {
+            throw new \InvalidArgumentException(sprintf("Boundary value \"%s\" is not a valid number.", new String($boundary)));
+        }
+
+        $this->boundary = $boundary;
+    }
+
+    /**
+     * @param $value
+     * @return boolean
+     */
+    public function match($value)
+    {
+        if (!is_float($value) && !is_integer($value) && !is_double($value)) {
+            $this->error = sprintf("Value \"%s\" is not a valid number.", new String($value));
+            return false;
+        }
+
+        if ($value <= $this->boundary) {
+            $this->error = sprintf("Value \"%s\" is not greater than \"%s\".", new String($value), new String($this->boundary));
+            return false;
+        }
+
+        return $value > $this->boundary;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/InArray.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/InArray.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\ToString\String;
+
+class InArray implements PatternExpander
+{
+    /**
+     * @var null|string
+     */
+    private $error;
+
+    /**
+     * @var
+     */
+    private $value;
+
+    /**
+     * @param $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param $value
+     * @return boolean
+     */
+    public function match($value)
+    {
+        if (!is_array($value)) {
+            $this->error = sprintf("InArray expander require \"array\", got \"%s\".", new String($value));
+            return false;
+        }
+
+        if (!in_array($this->value, $value, true)) {
+            $this->error = sprintf("%s doesn't have \"%s\" element.", new String($value), new String($this->value));
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/LowerThan.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/LowerThan.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\ToString\String;
+
+class LowerThan implements PatternExpander
+{
+    /**
+     * @var
+     */
+    private $boundary;
+
+    /**
+     * @var null|string
+     */
+    private $error;
+
+    /**
+     * @param $boundary
+     */
+    public function __construct($boundary)
+    {
+        if (!is_float($boundary) && !is_integer($boundary) && !is_double($boundary)) {
+            throw new \InvalidArgumentException(sprintf("Boundary value \"%s\" is not a valid number.", new String($boundary)));
+        }
+
+        $this->boundary = $boundary;
+    }
+
+    /**
+     * @param $value
+     * @return boolean
+     */
+    public function match($value)
+    {
+        if (!is_float($value) && !is_integer($value) && !is_double($value)) {
+            $this->error = sprintf("Value \"%s\" is not a valid number.", new String($value));
+            return false;
+        }
+
+        if ($value >= $this->boundary) {
+            $this->error = sprintf("Value \"%s\" is not lower than \"%s\".", new String($value), new String($this->boundary));
+            return false;
+        }
+
+        return $value < $this->boundary;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/NotEmpty.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/NotEmpty.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\ToString\String;
+
+class NotEmpty implements PatternExpander
+{
+    private $error;
+
+    /**
+     * @param $value
+     * @return boolean
+     */
+    public function match($value)
+    {
+        if (false === $value || (empty($value) && '0' != $value)) {
+            $this->error = sprintf("Value %s is not blank.", new String($value));
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/StartsWith.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/StartsWith.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\ToString\String;
+
+class StartsWith implements PatternExpander
+{
+    /**
+     * @var
+     */
+    private $stringBeginning;
+
+    /**
+     * @var null|string
+     */
+    private $error;
+
+    /**
+     * @var bool
+     */
+    private $ignoreCase;
+
+    /**
+     * @param string $stringBeginning
+     * @param bool $ignoreCase
+     */
+    public function __construct($stringBeginning, $ignoreCase = false)
+    {
+        if (!is_string($stringBeginning)) {
+            throw new \InvalidArgumentException("String beginning must be a valid string.");
+        }
+
+        $this->stringBeginning = $stringBeginning;
+        $this->ignoreCase = $ignoreCase;
+    }
+
+    /**
+     * @param $value
+     * @return boolean
+     */
+    public function match($value)
+    {
+        if (!is_string($value)) {
+            $this->error = sprintf("StartsWith expander require \"string\", got \"%s\".", new String($value));
+            return false;
+        }
+
+        if (empty($this->stringBeginning)) {
+            return true;
+        }
+
+        if ($this->matchValue($value)) {
+            $this->error = sprintf("string \"%s\" doesn't starts with string \"%s\".", $value, $this->stringBeginning);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * @param $value
+     * @return bool
+     */
+    protected function matchValue($value)
+    {
+        return $this->ignoreCase
+            ? mb_strpos(mb_strtolower($value), mb_strtolower($this->stringBeginning)) !== 0
+            : mb_strpos($value, $this->stringBeginning) !== 0;
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/Pattern.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/Pattern.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern;
+
+interface Pattern
+{
+    /**
+     * @param PatternExpander $expander
+     */
+    public function addExpander(PatternExpander $expander);
+
+    /**
+     * @param $value
+     * @return boolean
+     */
+    public function matchExpanders($value);
+
+    /**
+     * Return error message from first expander that doesn't match.
+     *
+     * @return null|string
+     */
+    public function getError();
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/PatternExpander.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/PatternExpander.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern;
+
+interface PatternExpander
+{
+    /**
+     * @param $value
+     * @return boolean
+     */
+    public function match($value);
+
+    /**
+     * @return string|null
+     */
+    public function getError();
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/TypePattern.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/TypePattern.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern;
+
+class TypePattern implements Pattern
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var PatternExpander[]|array
+     */
+    private $expanders;
+
+    /**
+     * @var null|string
+     */
+    private $error;
+
+    /**
+     * @param string $type
+     */
+    public function __construct($type)
+    {
+        $this->type = $type;
+        $this->expanders = array();
+    }
+
+    /**
+     * @param $type
+     * @return boolean
+     */
+    public function is($type)
+    {
+        return strtolower($this->type) === strtolower($type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addExpander(PatternExpander $expander)
+    {
+        $this->expanders[] = $expander;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matchExpanders($value)
+    {
+        foreach ($this->expanders as $expander) {
+            if (!$expander->match($value)) {
+                $this->error = $expander->getError();
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher/StringMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/StringMatcher.php
@@ -2,11 +2,23 @@
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Parser;
 use Coduo\ToString\String;
 
 class StringMatcher extends Matcher
 {
-    const STRING_PATTERN = '/^@string@$/';
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    /**
+     * @param Parser $parser
+     */
+    public function __construct(Parser $parser)
+    {
+        $this->parser = $parser;
+    }
 
     /**
      * {@inheritDoc}
@@ -18,6 +30,12 @@ class StringMatcher extends Matcher
             return false;
         }
 
+        $typePattern = $this->parser->parse($pattern);
+        if (!$typePattern->matchExpanders($value)) {
+            $this->error = $typePattern->getError();
+            return false;
+        }
+
         return true;
     }
 
@@ -26,6 +44,10 @@ class StringMatcher extends Matcher
      */
     public function canMatch($pattern)
     {
-        return is_string($pattern) && 0 !== preg_match(self::STRING_PATTERN, $pattern);
+        if (!is_string($pattern)) {
+            return false;
+        }
+
+        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is('string');
     }
 }

--- a/src/Coduo/PHPMatcher/Parser.php
+++ b/src/Coduo/PHPMatcher/Parser.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace Coduo\PHPMatcher;
+
+use Coduo\PHPMatcher\AST;
+use Coduo\PHPMatcher\Exception\Exception;
+use Coduo\PHPMatcher\Exception\InvalidExpanderTypeException;
+use Coduo\PHPMatcher\Exception\PatternException;
+use Coduo\PHPMatcher\Exception\UnknownExpanderClassException;
+use Coduo\PHPMatcher\Exception\UnknownExpanderException;
+use Coduo\PHPMatcher\Matcher\Pattern;
+
+class Parser
+{
+    const NULL_VALUE = 'null';
+
+    /**
+     * @var Lexer
+     */
+    private $lexer;
+
+    /**
+     * @var array
+     */
+    private $expanderDefinitions = array(
+        "startsWith" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\StartsWith",
+        "endsWith" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\EndsWith",
+        "notEmpty" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\NotEmpty",
+        "lowerThan" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\LowerThan",
+        "greaterThan" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\GreaterThan",
+        "inArray" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\InArray",
+        "contains" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\Contains"
+    );
+
+    /**
+     * @param Lexer $lexer
+     */
+    public function __construct(Lexer $lexer)
+    {
+        $this->lexer = $lexer;
+    }
+
+    /**
+     * @param string $pattern
+     * @return bool
+     */
+    public function hasValidSyntax($pattern)
+    {
+        try {
+            $this->getAST($pattern);
+            return true;
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param string $pattern
+     * @throws UnknownExpanderException
+     * @return Pattern\TypePattern
+     */
+    public function parse($pattern)
+    {
+        $AST = $this->getAST($pattern);
+        $pattern = new Pattern\TypePattern((string) $AST->getType());
+        foreach ($AST->getExpanders() as $expander) {
+            if (!array_key_exists($expander->getName(), $this->expanderDefinitions)) {
+                throw new UnknownExpanderException(sprintf("Unknown expander \"%s\"", $expander->getName()));
+            }
+
+            $pattern->addExpander($this->initializeExpander($expander));
+        }
+
+        return $pattern;
+    }
+
+    /**
+     * @param $pattern
+     * @return AST\Pattern
+     */
+    public function getAST($pattern)
+    {
+        $this->lexer->setInput($pattern);
+        return $this->getPattern();
+    }
+
+    /**
+     * @param $expanderName
+     * @param $expanderFQCN Fully-Qualified Class Name that implements PatternExpander interface
+     * @throws UnknownExpanderClassException
+     */
+    public function addExpanderDefinition($expanderName, $expanderFQCN)
+    {
+        if (!class_exists($expanderFQCN)) {
+            throw new UnknownExpanderClassException(sprintf("Class \"%s\" does not exists.", $expanderFQCN));
+        }
+
+        $this->expanderDefinitions[$expanderName] = $expanderFQCN;
+    }
+
+    /**
+     * Create AST root
+     *
+     * @return AST\Pattern
+     */
+    private function getPattern()
+    {
+        $this->lexer->moveNext();
+
+        switch ($this->lexer->lookahead['type']) {
+            case Lexer::T_TYPE_PATTERN:
+                $pattern = new AST\Pattern(new AST\Type($this->lexer->lookahead['value']));
+                break;
+            default:
+                $this->unexpectedSyntaxError($this->lexer->lookahead, "@type@ pattern");
+                break;
+        }
+
+        $this->lexer->moveNext();
+
+        if (!$this->endOfPattern()) {
+            $this->addExpanderNodes($pattern);
+        }
+
+        return $pattern;
+    }
+
+    /**
+     * @param AST\Pattern $pattern
+     */
+    private function addExpanderNodes(AST\Pattern $pattern)
+    {
+        while(($expander = $this->getNextExpanderNode()) !== null)  {
+            $pattern->addExpander($expander);
+        }
+    }
+
+    /**
+     * Try to get next expander, return null if there is no expander left
+     * @return AST\Expander|null
+     */
+    private function getNextExpanderNode()
+    {
+        if ($this->endOfPattern()) {
+            return ;
+        }
+
+        $expander = new AST\Expander($this->getExpanderName());
+
+        if ($this->endOfPattern()) {
+            $this->unexpectedEndOfString(")");
+        }
+
+        $this->addArgumentValues($expander);
+
+        if ($this->endOfPattern()) {
+            $this->unexpectedEndOfString(")");
+        }
+
+        if (!$this->isNextCloseParenthesis()) {
+            $this->unexpectedSyntaxError($this->lexer->lookahead, ")");
+        }
+
+        return $expander;
+    }
+
+    /**
+     * @return mixed
+     * @throws PatternException
+     */
+    private function getExpanderName()
+    {
+        if ($this->lexer->lookahead['type'] !== Lexer::T_EXPANDER_NAME) {
+            $this->unexpectedSyntaxError($this->lexer->lookahead, ".expanderName(args) definition");
+        }
+        $expander = $this->lexer->lookahead['value'];
+        $this->lexer->moveNext();
+
+        return $expander;
+    }
+
+    /**
+     * Add arguments to expander
+     *
+     * @param AST\Expander $expander
+     */
+    private function addArgumentValues(AST\Expander $expander)
+    {
+        while(($argument = $this->getNextArgumentValue()) !== null) {
+            $argument = ($argument === self::NULL_VALUE) ? null : $argument;
+            $expander->addArgument($argument);
+            if (!$this->lexer->isNextToken(Lexer::T_COMMA)){
+                break;
+            }
+
+            $this->lexer->moveNext();
+
+            if ($this->lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
+                $this->unexpectedSyntaxError($this->lexer->lookahead, "string, number, boolean or null argument");
+            }
+        }
+    }
+
+    /**
+     * Try to get next argument. Return false if there are no arguments left before ")"
+     * @return null|mixed
+     */
+    private function getNextArgumentValue()
+    {
+        $validArgumentTypes = array(
+            Lexer::T_STRING,
+            Lexer::T_NUMBER,
+            Lexer::T_BOOLEAN,
+            Lexer::T_NULL
+        );
+
+        if ($this->lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
+            return ;
+        }
+
+        if ($this->lexer->isNextToken(Lexer::T_OPEN_CURLY_BRACE)) {
+            return $this->getArrayArgument();
+        }
+
+        if (!$this->lexer->isNextTokenAny($validArgumentTypes)) {
+            $this->unexpectedSyntaxError($this->lexer->lookahead, "string, number, boolean or null argument");
+        }
+
+        $tokenType = $this->lexer->lookahead['type'];
+        $argument = $this->lexer->lookahead['value'];
+        $this->lexer->moveNext();
+
+        if ($tokenType === Lexer::T_NULL) {
+            $argument = self::NULL_VALUE;
+        }
+
+        return $argument;
+    }
+
+    /**
+     * return array
+     */
+    private function getArrayArgument()
+    {
+        $arrayArgument = array();
+        $this->lexer->moveNext();
+
+        while ($this->getNextArrayElement($arrayArgument) !== null) {
+            $this->lexer->moveNext();
+        }
+
+        if (!$this->lexer->isNextToken(Lexer::T_CLOSE_CURLY_BRACE)) {
+            $this->unexpectedSyntaxError($this->lexer->lookahead, "}");
+        }
+
+        $this->lexer->moveNext();
+
+        return $arrayArgument;
+    }
+
+    /**
+     * @param array $array
+     * @return bool
+     * @throws PatternException
+     */
+    private function getNextArrayElement(array &$array)
+    {
+        if ($this->lexer->isNextToken(Lexer::T_CLOSE_CURLY_BRACE)) {
+            return ;
+        }
+
+        $key = $this->getNextArgumentValue();
+        if ($key === self::NULL_VALUE) {
+            $key = "";
+        }
+
+        if (!$this->lexer->isNextToken(Lexer::T_COLON)) {
+            $this->unexpectedSyntaxError($this->lexer->lookahead, ":");
+        }
+
+        $this->lexer->moveNext();
+
+        $value = $this->getNextArgumentValue();
+        if ($value === self::NULL_VALUE) {
+            $value = null;
+        }
+
+        $array[$key] = $value;
+
+        if (!$this->lexer->isNextToken(Lexer::T_COMMA)) {
+            return ;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    private function isNextCloseParenthesis()
+    {
+        $isCloseParenthesis = $this->lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS);
+        $this->lexer->moveNext();
+
+        return $isCloseParenthesis;
+    }
+
+    /**
+     * @param $unexpectedToken
+     * @param null $expected
+     * @throws PatternException
+     */
+    private function unexpectedSyntaxError($unexpectedToken, $expected = null)
+    {
+        $tokenPos = (isset($unexpectedToken['position'])) ? $unexpectedToken['position'] : '-1';
+        $message  = sprintf("line 0, col %d: Error: ", $tokenPos);
+        $message .= (isset($expected)) ? sprintf("Expected \"%s\", got ", $expected) : "Unexpected";
+        $message .= sprintf("\"%s\"", $unexpectedToken['value']);
+
+        throw PatternException::syntaxError($message);
+    }
+
+    /**
+     * @param null $expected
+     * @throws PatternException
+     */
+    private function unexpectedEndOfString($expected = null)
+    {
+        $tokenPos = (isset($this->lexer->token['position'])) ? $this->lexer->token['position'] + strlen($this->lexer->token['value']) : '-1';
+        $message  = sprintf("line 0, col %d: Error: ", $tokenPos);
+        $message .= (isset($expected)) ? sprintf("Expected \"%s\", got end of string.", $expected) : "Unexpected";
+        $message .= "end of string";
+
+        throw PatternException::syntaxError($message);
+    }
+
+    /**
+     * @return bool
+     */
+    private function endOfPattern()
+    {
+        return is_null($this->lexer->lookahead);
+    }
+
+    /**
+     * @param AST\Expander $expander
+     * @throws InvalidExpanderTypeException
+     * @return Pattern\PatternExpander
+     */
+    private function initializeExpander(AST\Expander $expander)
+    {
+        $reflection = new \ReflectionClass($this->expanderDefinitions[$expander->getName()]);
+        $expander = !$expander->hasArguments()
+            ? $reflection->newInstance()
+            : $reflection->newInstanceArgs($expander->getArguments());
+
+        if (!$expander instanceof Pattern\PatternExpander) {
+            throw new InvalidExpanderTypeException();
+        }
+
+        return $expander;
+    }
+}

--- a/tests/Coduo/PHPMatcher/LexerTest.php
+++ b/tests/Coduo/PHPMatcher/LexerTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests;
+
+use Coduo\PHPMatcher\Lexer;
+
+class LexerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider validStringValuesProvider
+     */
+    public function test_string_values($value)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($value);
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_STRING);
+        $this->assertEquals($lexer->lookahead['value'], trim(trim($value, "'"), '"'));
+    }
+
+    public static function validStringValuesProvider()
+    {
+        return array(
+            array('"String"'),
+            array("'String'"),
+        );
+    }
+
+
+    /**
+     * @dataProvider validNumberValuesProvider
+     */
+    public function test_number_values($value, $expectedValue)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($value);
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_NUMBER);
+        $this->assertEquals($expectedValue, $lexer->lookahead['value']);
+    }
+
+    public static function validNumberValuesProvider()
+    {
+        return array(
+            array(1, 1),
+            array(1.25, 1.25),
+            array(0, 0),
+            array("125", 125),
+            array("12.15", 12.15),
+            array(-10, -10),
+            array(-1.124, -1.124),
+            array("-10", -10),
+            array("-1.24", -1.24)
+        );
+    }
+
+    /**
+     * @dataProvider validBooleanValuesProvider
+     */
+    public function test_boolean_values($value, $expectedValue)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($value);
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_BOOLEAN);
+        $this->assertEquals($lexer->lookahead['value'], $expectedValue);
+    }
+
+    public static function validBooleanValuesProvider()
+    {
+        return array(
+            array("true", true),
+            array("false", false),
+            array("TRUE", true),
+            array("fAlSe", false)
+        );
+    }
+
+    /**
+     * @dataProvider validNullValuesProvider
+     */
+    public function test_null_values($value)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($value);
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_NULL);
+        $this->assertNull($lexer->lookahead['value']);
+    }
+
+    public static function validNullValuesProvider()
+    {
+        return array(
+            array("null"),
+            array("NULL"),
+            array("NuLl"),
+        );
+    }
+
+    /**
+     * @dataProvider validNonTokenValuesProvider
+     */
+    public function test_non_token_values($value)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($value);
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_NONE);
+    }
+
+    public static function validNonTokenValuesProvider()
+    {
+        return array(
+            array("@integer"),
+            array("integer@"),
+            array("test"),
+            array("@")
+        );
+    }
+
+    public function test_close_parenthesis()
+    {
+        $lexer = new Lexer();
+        $lexer->setInput(')');
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function test_close_open_brace()
+    {
+        $lexer = new Lexer();
+        $lexer->setInput('{');
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_OPEN_CURLY_BRACE);
+    }
+
+    public function test_close_curly_brace()
+    {
+        $lexer = new Lexer();
+        $lexer->setInput('}');
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_CLOSE_CURLY_BRACE);
+    }
+
+    public function test_colon()
+    {
+        $lexer = new Lexer();
+        $lexer->setInput(':');
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_COLON);
+    }
+
+    public function test_comma()
+    {
+        $lexer = new Lexer();
+        $lexer->setInput(',');
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_COMMA);
+    }
+
+    /**
+     * @dataProvider validMatcherTypePatterns
+     */
+    public function test_type_pattern($value)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($value);
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_TYPE_PATTERN);
+        $this->assertEquals($lexer->lookahead['value'], trim($value, "@"));
+    }
+
+    public static function validMatcherTypePatterns()
+    {
+        return array(
+            array("@string@"),
+            array("@boolean@"),
+            array("@integer@"),
+            array("@number@"),
+            array("@*@"),
+            array("@wildcard@")
+        );
+    }
+
+    /**
+     * @dataProvider validExpanderNamesProvider
+     */
+    public function test_expander_name($value, $expectedTokenValue)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($value);
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_EXPANDER_NAME);
+        $this->assertEquals($lexer->lookahead['value'], $expectedTokenValue);
+    }
+
+    public static function validExpanderNamesProvider()
+    {
+        return array(
+            array("expanderName(", "expanderName"),
+            array("e(", "e"),
+            array(".e(", "e")
+        );
+    }
+
+    public function test_ignore_whitespaces_between_parenthesis()
+    {
+        $expectedTokens = array("type", "expander", "arg1", ",", 2, ",", "arg3", ",", 4, ")");
+        $lexer = new Lexer();
+        $lexer->setInput("@type@.expander( 'arg1',    2    ,'arg3',4)");
+
+        $this->assertEquals($expectedTokens, $this->collectTokens($lexer));
+    }
+
+    /**
+     * @param $lexer
+     * @return array
+     */
+    protected function collectTokens(Lexer $lexer)
+    {
+        $tokens = array();
+        while ($lexer->moveNext()) {
+            $tokens[] = $lexer->lookahead['value'];
+        }
+        return $tokens;
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/ArrayMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/ArrayMatcherTest.php
@@ -1,7 +1,10 @@
 <?php
+
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Parser;
 
 class ArrayMatcherTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,19 +15,21 @@ class ArrayMatcherTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        $parser = new Parser(new Lexer());
         $this->matcher = new Matcher\ArrayMatcher(
             new Matcher\ChainMatcher(array(
                 new Matcher\CallbackMatcher(),
                 new Matcher\ExpressionMatcher(),
                 new Matcher\NullMatcher(),
-                new Matcher\StringMatcher(),
-                new Matcher\IntegerMatcher(),
+                new Matcher\StringMatcher($parser),
+                new Matcher\IntegerMatcher($parser),
                 new Matcher\BooleanMatcher(),
-                new Matcher\DoubleMatcher(),
+                new Matcher\DoubleMatcher($parser),
                 new Matcher\NumberMatcher(),
                 new Matcher\ScalarMatcher(),
                 new Matcher\WildcardMatcher(),
-            ))
+            )),
+            $parser
         );
     }
 
@@ -49,7 +54,8 @@ class ArrayMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher = new Matcher\ArrayMatcher(
             new Matcher\ChainMatcher(array(
                 new Matcher\WildcardMatcher()
-            ))
+            )),
+            $parser = new Parser(new Lexer())
         );
 
         $this->assertFalse($matcher->match(array('test' => 1), array('test' => 1)));
@@ -106,6 +112,14 @@ class ArrayMatcherTest extends \PHPUnit_Framework_TestCase
     public function test_matching_array_to_array_pattern()
     {
         $this->assertTrue($this->matcher->match(array("foo", "bar"), "@array@"));
+        $this->assertTrue($this->matcher->match(array("foo"), "@array@.inArray(\"foo\")"));
+        $this->assertTrue($this->matcher->match(
+            array("foo", array("bar")),
+            array(
+                "@string@",
+                "@array@.inArray(\"bar\")"
+            )
+        ));
     }
 
     public static function positiveMatchData()

--- a/tests/Coduo/PHPMatcher/Matcher/DoubleMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/DoubleMatcherTest.php
@@ -1,17 +1,28 @@
 <?php
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\DoubleMatcher;
+use Coduo\PHPMatcher\Parser;
 
 class DoubleMatcherTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var DoubleMatcher
+     */
+    private $matcher;
+
+    public function setUp()
+    {
+        $this->matcher = new DoubleMatcher(new Parser(new Lexer()));
+    }
+
     /**
      * @dataProvider positiveCanMatchData
      */
     public function test_positive_can_matches($pattern)
     {
-        $matcher = new DoubleMatcher();
-        $this->assertTrue($matcher->canMatch($pattern));
+        $this->assertTrue($this->matcher->canMatch($pattern));
     }
 
     /**
@@ -19,8 +30,7 @@ class DoubleMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_negative_can_matches($pattern)
     {
-        $matcher = new DoubleMatcher();
-        $this->assertFalse($matcher->canMatch($pattern));
+        $this->assertFalse($this->matcher->canMatch($pattern));
     }
 
     /**
@@ -28,8 +38,7 @@ class DoubleMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_positive_match($value, $pattern)
     {
-        $matcher = new DoubleMatcher();
-        $this->assertTrue($matcher->match($value, $pattern));
+        $this->assertTrue($this->matcher->match($value, $pattern));
     }
 
     /**
@@ -37,8 +46,7 @@ class DoubleMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_negative_match($value, $pattern)
     {
-        $matcher = new DoubleMatcher();
-        $this->assertFalse($matcher->match($value, $pattern));
+        $this->assertFalse($this->matcher->match($value, $pattern));
     }
 
     /**
@@ -46,9 +54,8 @@ class DoubleMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_negative_match_description($value, $pattern, $error)
     {
-        $matcher = new DoubleMatcher();
-        $matcher->match($value, $pattern);
-        $this->assertEquals($error, $matcher->getError());
+        $this->matcher->match($value, $pattern);
+        $this->assertEquals($error, $this->matcher->getError());
     }
 
     public static function positiveCanMatchData()
@@ -62,6 +69,7 @@ class DoubleMatcherTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(10.1, "@double@"),
+            array(10.1, "@double@.lowerThan(50.12).greaterThan(10)"),
         );
     }
 
@@ -70,7 +78,7 @@ class DoubleMatcherTest extends \PHPUnit_Framework_TestCase
         return array(
             array("@double"),
             array("double"),
-            array(1)
+            array(1),
         );
     }
 
@@ -79,7 +87,9 @@ class DoubleMatcherTest extends \PHPUnit_Framework_TestCase
         return array(
             array("1", "@double@"),
             array(new \DateTime(),  "@double@"),
-            array(10,  "@double@")
+            array(10,  "@double@"),
+            array(4.9, "@double@.greaterThan(5)"),
+            array(4.9, "@double@.lowerThan(20).greaterThan(5)"),
         );
     }
 

--- a/tests/Coduo/PHPMatcher/Matcher/IntegerMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/IntegerMatcherTest.php
@@ -1,17 +1,28 @@
 <?php
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\IntegerMatcher;
+use Coduo\PHPMatcher\Parser;
 
 class IntegerMatcherTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var IntegerMatcher
+     */
+    private $matcher;
+
+    public function setUp()
+    {
+        $this->matcher = new IntegerMatcher(new Parser(new Lexer()));
+    }
+
     /**
      * @dataProvider positiveCanMatchData
      */
     public function test_positive_can_matches($pattern)
     {
-        $matcher = new IntegerMatcher();
-        $this->assertTrue($matcher->canMatch($pattern));
+        $this->assertTrue($this->matcher->canMatch($pattern));
     }
 
     /**
@@ -19,8 +30,7 @@ class IntegerMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_negative_can_matches($pattern)
     {
-        $matcher = new IntegerMatcher();
-        $this->assertFalse($matcher->canMatch($pattern));
+        $this->assertFalse($this->matcher->canMatch($pattern));
     }
 
     /**
@@ -28,8 +38,7 @@ class IntegerMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_positive_match($value, $pattern)
     {
-        $matcher = new IntegerMatcher();
-        $this->assertTrue($matcher->match($value, $pattern));
+        $this->assertTrue($this->matcher->match($value, $pattern));
     }
 
     /**
@@ -37,8 +46,7 @@ class IntegerMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_negative_match($value, $pattern)
     {
-        $matcher = new IntegerMatcher();
-        $this->assertFalse($matcher->match($value, $pattern));
+        $this->assertFalse($this->matcher->match($value, $pattern));
     }
 
     /**
@@ -46,9 +54,8 @@ class IntegerMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_negative_match_description($value, $pattern, $error)
     {
-        $matcher = new IntegerMatcher();
-        $matcher->match($value, $pattern);
-        $this->assertEquals($error, $matcher->getError());
+        $this->matcher->match($value, $pattern);
+        $this->assertEquals($error, $this->matcher->getError());
     }
 
     public static function positiveCanMatchData()
@@ -62,6 +69,7 @@ class IntegerMatcherTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(10, "@integer@"),
+            array(10, "@integer@.lowerThan(50).greaterThan(1)"),
         );
     }
 

--- a/tests/Coduo/PHPMatcher/Matcher/JsonMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/JsonMatcherTest.php
@@ -1,7 +1,10 @@
 <?php
+
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Parser;
 
 class JsonMatcherTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,21 +15,22 @@ class JsonMatcherTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        $parser = new Parser(new Lexer());
         $scalarMatchers = new Matcher\ChainMatcher(array(
             new Matcher\CallbackMatcher(),
             new Matcher\ExpressionMatcher(),
             new Matcher\NullMatcher(),
-            new Matcher\StringMatcher(),
-            new Matcher\IntegerMatcher(),
+            new Matcher\StringMatcher($parser),
+            new Matcher\IntegerMatcher($parser),
             new Matcher\BooleanMatcher(),
-            new Matcher\DoubleMatcher(),
+            new Matcher\DoubleMatcher($parser),
             new Matcher\NumberMatcher(),
             new Matcher\ScalarMatcher(),
             new Matcher\WildcardMatcher(),
         ));
         $this->matcher = new Matcher\JsonMatcher(new Matcher\ChainMatcher(array(
             $scalarMatchers,
-            new Matcher\ArrayMatcher($scalarMatchers)
+            new Matcher\ArrayMatcher($scalarMatchers, $parser)
         )));
     }
 

--- a/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/ContainsTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/ContainsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\Contains;
+
+class ContainsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider examplesIgnoreCaseProvider
+     */
+    public function test_matching_values_ignore_case($needle, $haystack, $expectedResult)
+    {
+        $expander = new Contains($needle);
+        $this->assertEquals($expectedResult, $expander->match($haystack));
+    }
+
+    public static function examplesIgnoreCaseProvider()
+    {
+        return array(
+            array("ipsum", "lorem ipsum", true),
+            array("wor", "this is my hello world string", true),
+            array("lol", "lorem ipsum", false),
+            array("NO", "norbert", false)
+        );
+    }
+
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_matching_values($needle, $haystack, $expectedResult)
+    {
+        $expander = new Contains($needle, true);
+        $this->assertEquals($expectedResult, $expander->match($haystack));
+    }
+
+    public static function examplesProvider()
+    {
+        return array(
+            array("IpSum", "lorem ipsum", true),
+            array("wor", "this is my hello WORLD string", true),
+            array("lol", "LOREM ipsum", false),
+            array("NO", "NORBERT", true)
+        );
+    }
+
+    /**
+     * @dataProvider invalidCasesProvider
+     */
+    public function test_error_when_matching_fail($string, $value, $errorMessage)
+    {
+        $expander = new Contains($string);
+        $this->assertFalse($expander->match($value));
+        $this->assertEquals($errorMessage, $expander->getError());
+    }
+
+    public static function invalidCasesProvider()
+    {
+        return array(
+            array("ipsum", "hello world", "String \"hello world\" doesn't contains \"ipsum\"."),
+            array("lorem", new \DateTime(), "Contains expander require \"string\", got \"\\DateTime\"."),
+        );
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/EndsWithTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/EndsWithTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\EndsWith;
+
+class EndsWithTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider notIgnoringCaseExamplesProvider
+     */
+    public function test_examples_not_ignoring_case($stringEnding, $value, $expectedResult)
+    {
+        $expander = new EndsWith($stringEnding);
+        $this->assertEquals($expectedResult, $expander->match($value));
+    }
+
+    public static function notIgnoringCaseExamplesProvider()
+    {
+        return array(
+            array("ipsum", "lorem ipsum", true),
+            array("ipsum", "Lorem IPSUM", false),
+            array("", "lorem ipsum", true),
+            array("ipsum", "lorem ipsum", true),
+            array("lorem", "lorem ipsum", false)
+        );
+    }
+
+    /**
+     * @dataProvider ignoringCaseExamplesProvider
+     */
+    public function test_examples_ignoring_case($stringEnding, $value, $expectedResult)
+    {
+        $expander = new EndsWith($stringEnding, true);
+        $this->assertEquals($expectedResult, $expander->match($value));
+    }
+
+    public static function ignoringCaseExamplesProvider()
+    {
+        return array(
+            array("Ipsum", "Lorem ipsum", true),
+            array("iPsUm", "lorem ipsum", true),
+            array("IPSUM", "LoReM ipsum", true),
+        );
+    }
+
+    /**
+     * @dataProvider invalidCasesProvider
+     */
+    public function test_error_when_matching_fail($stringBeginning, $value, $errorMessage)
+    {
+        $expander = new EndsWith($stringBeginning);
+        $this->assertFalse($expander->match($value));
+        $this->assertEquals($errorMessage, $expander->getError());
+    }
+
+    public static function invalidCasesProvider()
+    {
+        return array(
+            array("ipsum", "ipsum lorem", "string \"ipsum lorem\" doesn't ends with string \"ipsum\"."),
+            array("lorem", new \DateTime(), "EndsWith expander require \"string\", got \"\\DateTime\"."),
+        );
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/GreaterThanTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/GreaterThanTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\GreaterThan;
+
+class GreaterThanTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_examples($boundary, $value, $expectedResult)
+    {
+        $expander = new GreaterThan($boundary);
+        $this->assertEquals($expectedResult, $expander->match($value));
+    }
+
+    public static function examplesProvider()
+    {
+        return array(
+            array(10, 10.5, true),
+            array(-20, -10.5, true),
+            array(10, 1, false),
+            array(1, 1, false),
+        );
+    }
+
+    /**
+     * @dataProvider invalidCasesProvider
+     */
+    public function test_error_when_matching_fail($boundary, $value, $errorMessage)
+    {
+        $expander = new GreaterThan($boundary);
+        $this->assertFalse($expander->match($value));
+        $this->assertEquals($errorMessage, $expander->getError());
+    }
+
+    public static function invalidCasesProvider()
+    {
+        return array(
+            array(1, "ipsum lorem", "Value \"ipsum lorem\" is not a valid number."),
+            array(10, 5, "Value \"5\" is not greater than \"10\"."),
+            array(5, 5, "Value \"5\" is not greater than \"5\"."),
+        );
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/InArrayTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/InArrayTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\InArray;
+
+class InArrayTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_matching_values($needle, $haystack, $expectedResult)
+    {
+        $expander = new InArray($needle);
+        $this->assertEquals($expectedResult, $expander->match($haystack));
+    }
+
+    public static function examplesProvider()
+    {
+        return array(
+            array("ipsum", array("ipsum"), true),
+            array(1, array("foo", 1), true),
+            array(array("foo" => "bar"), array(array("foo" => "bar")), true),
+        );
+    }
+
+    /**
+     * @dataProvider invalidCasesProvider
+     */
+    public function test_error_when_matching_fail($boundary, $value, $errorMessage)
+    {
+        $expander = new InArray($boundary);
+        $this->assertFalse($expander->match($value));
+        $this->assertEquals($errorMessage, $expander->getError());
+    }
+
+    public static function invalidCasesProvider()
+    {
+        return array(
+            array("ipsum", array("ipsum lorem"), "Array(1) doesn't have \"ipsum\" element."),
+            array("lorem", new \DateTime(), "InArray expander require \"array\", got \"\\DateTime\"."),
+        );
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/LowerThanTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/LowerThanTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\LowerThan;
+
+class LowerThanTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_examples($boundary, $value, $expectedResult)
+    {
+        $expander = new LowerThan($boundary);
+        $this->assertEquals($expectedResult, $expander->match($value));
+    }
+
+    public static function examplesProvider()
+    {
+        return array(
+            array(10.5, 10, true),
+            array(-10.5, -20, true),
+            array(1, 10, false),
+            array(1, 1, false),
+        );
+    }
+
+    /**
+     * @dataProvider invalidCasesProvider
+     */
+    public function test_error_when_matching_fail($boundary, $value, $errorMessage)
+    {
+        $expander = new LowerThan($boundary);
+        $this->assertFalse($expander->match($value));
+        $this->assertEquals($errorMessage, $expander->getError());
+    }
+
+    public static function invalidCasesProvider()
+    {
+        return array(
+            array(1, "ipsum lorem", "Value \"ipsum lorem\" is not a valid number."),
+            array(5, 10, "Value \"10\" is not lower than \"5\"."),
+            array(5, 5, "Value \"5\" is not lower than \"5\"."),
+        );
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/NotBlankTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/NotBlankTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\NotEmpty;
+
+class NotEmptyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_examples_not_ignoring_case($value, $expectedResult)
+    {
+        $expander = new NotEmpty();
+        $this->assertEquals($expectedResult, $expander->match($value));
+    }
+
+    public static function examplesProvider()
+    {
+        return array(
+            array("lorem", true),
+            array("0", true),
+            array(new \DateTime(), true),
+            array("", false),
+            array(null, false),
+            array(array(), false)
+        );
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/StartsWithTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/StartsWithTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\StartsWith;
+
+class StartsWithTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider notIgnoringCaseExamplesProvider
+     */
+    public function test_examples_not_ignoring_case($stringBeginning, $value, $expectedResult)
+    {
+        $expander = new StartsWith($stringBeginning);
+        $this->assertEquals($expectedResult, $expander->match($value));
+    }
+
+    public static function notIgnoringCaseExamplesProvider()
+    {
+        return array(
+            array("lorem", "lorem ipsum", true),
+            array("lorem", "Lorem ipsum", false),
+            array("", "lorem ipsum", true),
+            array("lorem", "lorem ipsum", true),
+            array("ipsum", "lorem ipsum", false)
+        );
+    }
+
+    /**
+     * @dataProvider ignoringCaseExamplesProvider
+     */
+    public function test_examples_ignoring_case($stringBeginning, $value, $expectedResult)
+    {
+        $expander = new StartsWith($stringBeginning, true);
+        $this->assertTrue($expander->match($value));
+    }
+
+    public static function ignoringCaseExamplesProvider()
+    {
+        return array(
+            array("lorem", "Lorem ipsum", true),
+            array("Lorem", "lorem ipsum", true),
+            array("LOREM", "LoReM ipsum", true),
+        );
+    }
+
+    /**
+     * @dataProvider invalidCasesProvider
+     */
+    public function test_error_when_matching_fail($stringBeginning, $value, $errorMessage)
+    {
+        $expander = new StartsWith($stringBeginning);
+        $this->assertFalse($expander->match($value));
+        $this->assertEquals($errorMessage, $expander->getError());
+    }
+
+    public static function invalidCasesProvider()
+    {
+        return array(
+            array("lorem", "ipsum lorem", "string \"ipsum lorem\" doesn't starts with string \"lorem\"."),
+            array("lorem", new \DateTime(), "StartsWith expander require \"string\", got \"\\DateTime\"."),
+        );
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/StringMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/StringMatcherTest.php
@@ -1,17 +1,29 @@
 <?php
+
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\StringMatcher;
+use Coduo\PHPMatcher\Parser;
 
 class StringMatcherTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var StringMatcher
+     */
+    private $matcher;
+
+    public function setUp()
+    {
+        $parser = new Parser(new Lexer());
+        $this->matcher = new StringMatcher($parser);
+    }
     /**
      * @dataProvider positiveCanMatchData
      */
     public function test_positive_can_matches($pattern)
     {
-        $matcher = new StringMatcher();
-        $this->assertTrue($matcher->canMatch($pattern));
+        $this->assertTrue($this->matcher->canMatch($pattern));
     }
 
     /**
@@ -19,8 +31,7 @@ class StringMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_negative_can_matches($pattern)
     {
-        $matcher = new StringMatcher();
-        $this->assertFalse($matcher->canMatch($pattern));
+        $this->assertFalse($this->matcher->canMatch($pattern));
     }
 
     /**
@@ -28,8 +39,7 @@ class StringMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_positive_match($value, $pattern)
     {
-        $matcher = new StringMatcher();
-        $this->assertTrue($matcher->match($value, $pattern));
+        $this->assertTrue($this->matcher->match($value, $pattern));
     }
 
     /**
@@ -37,8 +47,7 @@ class StringMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_negative_match($value, $pattern)
     {
-        $matcher = new StringMatcher();
-        $this->assertFalse($matcher->match($value, $pattern));
+        $this->assertFalse($this->matcher->match($value, $pattern));
     }
 
     /**
@@ -46,9 +55,8 @@ class StringMatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function test_negative_match_description($value, $pattern, $error)
     {
-        $matcher = new StringMatcher();
-        $matcher->match($value, $pattern);
-        $this->assertEquals($error, $matcher->getError());
+        $this->matcher->match($value, $pattern);
+        $this->assertEquals($error, $this->matcher->getError());
     }
 
     public static function positiveCanMatchData()
@@ -62,6 +70,10 @@ class StringMatcherTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array("lorem ipsum", "@string@"),
+            array("lorem ipsum", "@string@.notEmpty()"),
+            array("lorem ipsum", "@string@.startsWith('lorem')"),
+            array("lorem ipsum", "@string@.endsWith('ipsum')"),
+            array("lorem ipsum dolor", "@string@.startsWith('lorem').contains('ipsum').endsWith('dolor')"),
         );
     }
 
@@ -88,7 +100,8 @@ class StringMatcherTest extends \PHPUnit_Framework_TestCase
             array(new \stdClass,  "@string@", "object \"\\stdClass\" is not a valid string."),
             array(1.1, "@integer@", "double \"1.1\" is not a valid string."),
             array(false, "@double@", "boolean \"false\" is not a valid string."),
-            array(1, "@array@", "integer \"1\" is not a valid string.")
+            array(1, "@array@", "integer \"1\" is not a valid string."),
+            array("lorem ipsum", "@array@.startsWith('ipsum')", "string \"lorem ipsum\" doesn't starts with string \"ipsum\".")
         );
     }
 }

--- a/tests/Coduo/PHPMatcher/MatcherTest.php
+++ b/tests/Coduo/PHPMatcher/MatcherTest.php
@@ -1,16 +1,9 @@
 <?php
 namespace Coduo\PHPMatcher\Tests;
 
-use Coduo\PHPMatcher\Matcher\ArrayMatcher;
-use Coduo\PHPMatcher\Matcher\CaptureMatcher;
-use Coduo\PHPMatcher\Matcher\CallbackMatcher;
-use Coduo\PHPMatcher\Matcher\ChainMatcher;
-use Coduo\PHPMatcher\Matcher\ExpressionMatcher;
-use Coduo\PHPMatcher\Matcher\JsonMatcher;
-use Coduo\PHPMatcher\Matcher\ScalarMatcher;
-use Coduo\PHPMatcher\Matcher\TypeMatcher;
-use Coduo\PHPMatcher\Matcher\WildcardMatcher;
+use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Parser;
 
 class MatcherTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,28 +18,28 @@ class MatcherTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->captureMatcher = new CaptureMatcher();
-
-        $scalarMatchers = new ChainMatcher(array(
+        $this->captureMatcher = new Matcher\CaptureMatcher();
+        $parser = new Parser(new Lexer());
+        $scalarMatchers = new Matcher\ChainMatcher(array(
             $this->captureMatcher,
             new Matcher\CallbackMatcher(),
             new Matcher\ExpressionMatcher(),
             new Matcher\NullMatcher(),
-            new Matcher\StringMatcher(),
-            new Matcher\IntegerMatcher(),
+            new Matcher\StringMatcher($parser),
+            new Matcher\IntegerMatcher($parser),
             new Matcher\BooleanMatcher(),
-            new Matcher\DoubleMatcher(),
+            new Matcher\DoubleMatcher($parser),
             new Matcher\NumberMatcher(),
             new Matcher\ScalarMatcher(),
             new Matcher\WildcardMatcher(),
         ));
 
-        $arrayMatcher = new ArrayMatcher($scalarMatchers);
+        $arrayMatcher = new Matcher\ArrayMatcher($scalarMatchers, $parser);
 
-        $this->matcher = new Matcher(new ChainMatcher(array(
+        $this->matcher = new Matcher(new Matcher\ChainMatcher(array(
             $scalarMatchers,
             $arrayMatcher,
-            new JsonMatcher($arrayMatcher)
+            new Matcher\JsonMatcher($arrayMatcher)
         )));
     }
 

--- a/tests/Coduo/PHPMatcher/ParserSyntaxErrorTest.php
+++ b/tests/Coduo/PHPMatcher/ParserSyntaxErrorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests;
+
+use Coduo\PHPMatcher\Lexer;
+use Coduo\PHPMatcher\Parser;
+
+class ParserSyntaxErrorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    public function setUp()
+    {
+        $this->parser = new Parser(new Lexer());
+    }
+
+    /**
+     * @expectedException \Coduo\PHPMatcher\Exception\PatternException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 0: Error: Expected "@type@ pattern", got "not"
+     */
+    public function test_unexpected_statement_at_type_position()
+    {
+        $this->parser->getAST("not_valid_type");
+    }
+
+    /**
+     * @expectedException \Coduo\PHPMatcher\Exception\PatternException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 6: Error: Expected ".expanderName(args) definition", got "anything"
+     */
+    public function test_unexpected_statement_instead_of_expander()
+    {
+        $this->parser->getAST("@type@anything");
+    }
+
+    /**
+     * @expectedException \Coduo\PHPMatcher\Exception\PatternException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 14: Error: Expected ")", got end of string.end of string
+     */
+    public function test_end_of_string_after_opening_parenthesis()
+    {
+        $this->parser->getAST("@type@.expander(");
+    }
+
+    /**
+     * @expectedException \Coduo\PHPMatcher\Exception\PatternException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 16: Error: Expected "string, number, boolean or null argument", got "not"
+     */
+    public function test_not_argument_after_opening_parenthesis()
+    {
+        $this->parser->getAST("@type@.expander(not_argument");
+    }
+
+    /**
+     * @expectedException \Coduo\PHPMatcher\Exception\PatternException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 22: Error: Expected ")", got end of string.end of string
+     */
+    public function test_missing_close_parenthesis_after_single_argument()
+    {
+        $this->parser->getAST("@type@.expander('string'");
+    }
+
+    /**
+     * @expectedException \Coduo\PHPMatcher\Exception\PatternException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 26: Error: Expected ")", got end of string.end of string
+     */
+    public function test_missing_close_parenthesis_after_multiple_arguments()
+    {
+        $this->parser->getAST("@type@.expander('string',1");
+    }
+
+    /**
+     * @expectedException \Coduo\PHPMatcher\Exception\PatternException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 25: Error: Expected "string, number, boolean or null argument", got ")"
+     */
+    public function test_missing_argument_after_comma()
+    {
+        $this->parser->getAST("@type@.expander('string',)");
+    }
+
+    /**
+     * @expectedException \Coduo\PHPMatcher\Exception\PatternException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 25: Error: Expected "string, number, boolean or null argument", got "not"
+     */
+    public function test_not_argument_after_comma()
+    {
+        $this->parser->getAST("@type@.expander('string',not_argument");
+    }
+}

--- a/tests/Coduo/PHPMatcher/ParserTest.php
+++ b/tests/Coduo/PHPMatcher/ParserTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests;
+
+use Coduo\PHPMatcher\Lexer;
+use Coduo\PHPMatcher\Parser;
+
+class ParserTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    public function setUp()
+    {
+        $this->parser = new Parser(new Lexer());
+    }
+
+    public function test_simple_pattern_without_expanders()
+    {
+        $pattern = "@type@";
+
+        $this->assertEquals("type", $this->parser->getAST($pattern)->getType());
+        $this->assertFalse($this->parser->getAST($pattern)->hasExpanders());
+    }
+
+    public function test_single_expander_without_args()
+    {
+        $pattern = "@type@.expander()";
+
+        $this->assertEquals("type", $this->parser->getAST($pattern)->getType());
+        $expanders = $this->parser->getAST($pattern)->getExpanders();
+        $this->assertEquals('expander', $expanders[0]->getName());
+        $this->assertFalse($expanders[0]->hasArguments());
+    }
+
+    public function test_single_expander_with_arguments()
+    {
+        $pattern = "@type@.expander('arg1', 2, 2.24, \"arg3\")";
+        $this->assertEquals("type", $this->parser->getAST($pattern)->getType());
+        $expanders = $this->parser->getAST($pattern)->getExpanders();
+        $expectedArguments = array(
+            "arg1",
+            2,
+            2.24,
+            "arg3"
+        );
+        $this->assertEquals($expectedArguments, $expanders[0]->getArguments());
+    }
+
+    public function test_many_expanders()
+    {
+        $pattern = "@type@.expander('arg1', 2, 2.24, \"arg3\", null, false).expander1().expander(1,2,3, true, null)";
+        $expanderArguments = array(
+            array('arg1', 2, 2.24, 'arg3', null, false),
+            array(),
+            array(1, 2, 3, true, null)
+        );
+
+        $expanders = $this->parser->getAST($pattern)->getExpanders();
+        $this->assertEquals("type", $this->parser->getAST($pattern)->getType());
+        $this->assertEquals('expander', $expanders[0]->getName());
+        $this->assertEquals('expander1', $expanders[1]->getName());
+        $this->assertEquals('expander', $expanders[2]->getName());
+
+        $this->assertEquals($expanderArguments[0], $expanders[0]->getArguments());
+        $this->assertEquals($expanderArguments[1], $expanders[1]->getArguments());
+        $this->assertEquals($expanderArguments[2], $expanders[2]->getArguments());
+    }
+
+    /**
+     * @dataProvider expandersWithArrayArguments
+     */
+    public function test_single_array_argument_with_string_key_value($pattern, $expectedArgument)
+    {
+        $expanders = $this->parser->getAST($pattern)->getExpanders();
+        $this->assertEquals($expectedArgument, $expanders[0]->getArguments());
+    }
+
+    public static function expandersWithArrayArguments()
+    {
+        return array(
+            array(
+                "@type@.expander({\"foo\":\"bar\"})",
+                array(array("foo" => "bar"))
+            ),
+            array(
+                "@type@.expander({1 : \"bar\"})",
+                array(array(1 => "bar"))
+            ),
+            array(
+                "@type@.expander({\"foo\":\"bar\"}, {\"foz\" : \"baz\"})",
+                array(array("foo" => "bar"), array("foz" => "baz"))
+            ),
+            array(
+                "@type@.expander({1 : 1})",
+                array(array(1 => 1))
+            ),
+            array(
+                "@type@.expander({1 : true})",
+                array(array(1 => true))
+            ),
+            array(
+                "@type@.expander({1 : 1}, {1 : 1})",
+                array(array(1 => 1), array(1 => 1))
+            ),
+            array(
+                "@type@.expander({1 : {\"foo\" : \"bar\"}}, {1 : 1})",
+                array(array(1 => array("foo" => "bar")), array(1 => 1))
+            ),
+            array(
+                "@type@.expander({null: \"bar\"})",
+                array(array("" => "bar"))
+            ),
+            array(
+                "@type@.expander({\"foo\": null})",
+                array(array("foo" => null))
+            ),
+            array(
+                "@type@.expander({\"foo\" : \"bar\", \"foz\" : \"baz\"})",
+                array(array("foo" => "bar", "foz" => "baz"))
+            ),
+            array(
+                "@type@.expander({\"foo\" : \"bar\", \"foo\" : \"baz\"})",
+                array(array("foo" => "baz"))
+            ),
+            array(
+                "@type@.expander({\"foo\" : \"bar\", 1 : {\"first\" : 1, \"second\" : 2}})",
+                array(array("foo" => "bar", 1 => array("first" => 1, "second" => 2)))
+            )
+        );
+    }
+}


### PR DESCRIPTION
This implementation allows us to create multiple expanders for type patterns. 
Each expander can be created with unlimited amount of arguments. 
Supported argument types
- [x] string
- [x] number (float/integer)
- [x] boolean
- [x] null 
- [x] array 

There is only one available expander atm. 
- StartsWith($stringBeginning, $ignoreCase = false)
- EndsWith($stringEnding, $ignoreCase = false)
- NotEmpty()
- LowerThan($boundry)
- GreaterThan($boundry)
- InArray($value)

Example expander usage: 

``` php
$factory = new SimpleFactory();
$matcher = $factory->createMatcher();
$matcher->match("lorem ipsum", "@string@.startsWith('lorem')"); 
```

Syntax error in pattern expander will throw exception, example:

``` php
$factory = new SimpleFactory();
$matcher = $factory->createMatcher();
$matcher->match("lorem ipsum", "@type@.expander('string',not_argument"); 
// Exception message: [Syntax Error] line 0, col 25: Error: Expected "string or number argument", got "not_argument"
```

Pattern syntax: 

```
@type@.expander(args).expander(args).expander()
```

You can use as many expanders as you need. You can also create expanders without arguments. 
