### PR TITLE
Expanded TRANSFORM_QUOTATION_PATTERN in Json matcher to handle new type matchers

### DIFF
--- a/src/Coduo/PHPMatcher/Matcher/JsonMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/JsonMatcher.php
@@ -4,7 +4,7 @@ namespace Coduo\PHPMatcher\Matcher;
 
 class JsonMatcher extends Matcher
 {
-    const TRANSFORM_QUOTATION_PATTERN = '/([^"])@(integer|string|array|double|wildcard|boolean|\.\.\.|null)@([^"])/';
+    const TRANSFORM_QUOTATION_PATTERN = '/([^"])@([a-zA-Z0-9\.]+)@([^"])/';
     const TRANSFORM_QUOTATION_REPLACEMENT = '$1"@$2@"$3';
 
     /**

--- a/tests/Coduo/PHPMatcher/Matcher/JsonMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/JsonMatcherTest.php
@@ -59,6 +59,14 @@ class JsonMatcherTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider normalizationRequiredDataProvider
+     */
+    public function test_positive_matches_after_normalization($value, $pattern)
+    {
+        $this->assertTrue($this->matcher->match($value, $pattern), $this->matcher->getError());
+    }
+
+    /**
      * @dataProvider negativeMatches
      */
     public function test_negative_matches($value, $pattern)
@@ -191,6 +199,36 @@ class JsonMatcherTest extends \PHPUnit_Framework_TestCase
                 array(),
                 '[]'
             )
+        );
+    }
+
+    public static function normalizationRequiredDataProvider()
+    {
+        return array(
+            array(
+                '{"name": "Norbert"}',
+                '{"name": @string@}'
+            ),
+            array(
+                '{"name": 25}',
+                '{"name": @number@}'
+            ),
+            array(
+                '{"name": 25}',
+                '{"name": @integer@}'
+            ),
+            array(
+                '{"name": true}',
+                '{"name": @boolean@}'
+            ),
+            array(
+                '{"name": ["Norbert", "Michał"]}',
+                '{"name": ["Norbert", @...@]}'
+            ),
+            array(
+                '{"name": "Norbert", "roles": ["ADMIN", "USER"]}',
+                '{"name": @string@, "roles": [@string@, @string@]}'
+            ),
         );
     }
 }


### PR DESCRIPTION
Before this fix types like @boolean@ or @double@ were not supported.
After merge of this PR we should create a new tag. 
