### PR TITLE
Adds NonStrictArrayMatcher which will matches softly value and pattern

### DIFF
--- a/src/Coduo/PHPMatcher/Matcher/ArrayMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/ArrayMatcher.php
@@ -14,17 +14,17 @@ class ArrayMatcher extends Matcher
     /**
      * @var PropertyMatcher
      */
-    private $propertyMatcher;
+    protected $propertyMatcher;
 
     /**
      * @var PropertyAccessor
      */
-    private $accessor;
+    protected $accessor;
 
     /**
      * @var Parser
      */
-    private $parser;
+    protected $parser;
 
     /**
      * @param ValueMatcher $propertyMatcher
@@ -64,7 +64,7 @@ class ArrayMatcher extends Matcher
         return is_array($pattern) || $this->isArrayPattern($pattern);
     }
 
-    private function isArrayPattern($pattern)
+    protected function isArrayPattern($pattern)
     {
         if (!is_string($pattern)) {
             return false;
@@ -79,7 +79,7 @@ class ArrayMatcher extends Matcher
      * @param string $parentPath
      * @return bool
      */
-    private function iterateMatch(array $values, array $patterns, $parentPath = "")
+    protected function iterateMatch(array $values, array $patterns, $parentPath = "")
     {
         $pattern = null;
         foreach ($values as $key => $value) {
@@ -136,7 +136,7 @@ class ArrayMatcher extends Matcher
      * @param $parentPath
      * @return bool
      */
-    private function isPatternValid(array $pattern, array $values, $parentPath)
+    protected function isPatternValid(array $pattern, array $values, $parentPath)
     {
         if (is_array($pattern)) {
             $notExistingKeys = array_diff_key($pattern, $values);
@@ -157,7 +157,7 @@ class ArrayMatcher extends Matcher
      * @param $pattern
      * @return bool
      */
-    private function valueMatchPattern($value, $pattern)
+    protected function valueMatchPattern($value, $pattern)
     {
         $match = $this->propertyMatcher->canMatch($pattern) &&
             true === $this->propertyMatcher->match($value, $pattern);
@@ -174,7 +174,7 @@ class ArrayMatcher extends Matcher
      * @param $haystack
      * @return bool
      */
-    private function valueExist($path, array $haystack)
+    protected function valueExist($path, array $haystack)
     {
         return null !== $this->getPropertyAccessor()->getValue($haystack, $path);
     }
@@ -184,7 +184,7 @@ class ArrayMatcher extends Matcher
      * @param $path
      * @return mixed
      */
-    private function getValueByPath($array, $path)
+    protected function getValueByPath($array, $path)
     {
         return $this->getPropertyAccessor()->getValue($array, $path);
     }
@@ -192,7 +192,7 @@ class ArrayMatcher extends Matcher
     /**
      * @return \Symfony\Component\PropertyAccess\PropertyAccessorInterface
      */
-    private function getPropertyAccessor()
+    protected function getPropertyAccessor()
     {
         if (isset($this->accessor)) {
             return $this->accessor;
@@ -208,7 +208,7 @@ class ArrayMatcher extends Matcher
      * @param $place
      * @param $path
      */
-    private function setMissingElementInError($place, $path)
+    protected function setMissingElementInError($place, $path)
     {
         $this->error = sprintf('There is no element under path %s in %s.', $path, $place);
     }
@@ -217,7 +217,7 @@ class ArrayMatcher extends Matcher
      * @param $key
      * @return string
      */
-    private function formatAccessPath($key)
+    protected function formatAccessPath($key)
     {
         return sprintf("[%s]", $key);
     }
@@ -227,7 +227,7 @@ class ArrayMatcher extends Matcher
      * @param $path
      * @return string
      */
-    private function formatFullPath($parentPath, $path)
+    protected function formatFullPath($parentPath, $path)
     {
         return sprintf("%s%s", $parentPath, $path);
     }
@@ -236,7 +236,7 @@ class ArrayMatcher extends Matcher
      * @param $lastPattern
      * @return bool
      */
-    private function shouldSkippValueMatchingFor($lastPattern)
+    protected function shouldSkippValueMatchingFor($lastPattern)
     {
         return $lastPattern === self::UNBOUNDED_PATTERN;
     }
@@ -247,7 +247,7 @@ class ArrayMatcher extends Matcher
      * @return bool
      * @throws \Coduo\PHPMatcher\Exception\UnknownExpanderException
      */
-    private function allExpandersMatch($value, $pattern)
+    protected function allExpandersMatch($value, $pattern)
     {
         $typePattern = $this->parser->parse($pattern);
         if (!$typePattern->matchExpanders($value)) {

--- a/src/Coduo/PHPMatcher/Matcher/JsonMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/JsonMatcher.php
@@ -2,22 +2,28 @@
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Exception\Exception;
+
 class JsonMatcher extends Matcher
 {
     const TRANSFORM_QUOTATION_PATTERN = '/([^"])@([a-zA-Z0-9\.]+)@([^"])/';
     const TRANSFORM_QUOTATION_REPLACEMENT = '$1"@$2@"$3';
+    const IGNORE_EXTRA_KEYS_PATTERN = "@ignore_extra_keys@";
 
     /**
      * @var
      */
     private $matcher;
 
+    private $nonStrictMatcher;
+
     /**
      * @param ValueMatcher $matcher
      */
-    public function __construct(ValueMatcher $matcher)
+    public function __construct(ValueMatcher $matcher, ValueMatcher $nonStrictMatcher = null)
     {
         $this->matcher = $matcher;
+        $this->nonStrictMatcher = $nonStrictMatcher;
     }
 
     /**
@@ -25,12 +31,16 @@ class JsonMatcher extends Matcher
      */
     public function match($value, $pattern)
     {
+        $nonStrictMatching = $this->isNonStrict($pattern);
+
+        $pattern = $this->removeNonStrictPattern($pattern);
+
         if (!is_string($value) || !$this->isValidJson($value)) {
             return false;
         }
 
         $pattern = $this->transformPattern($pattern);
-        $match = $this->matcher->match(json_decode($value, true), json_decode($pattern, true));
+        $match = $this->doMatch(json_decode($value, true), json_decode($pattern, true), $nonStrictMatching);
         if (!$match) {
             $this->error = $this->matcher->getError();
             return false;
@@ -67,6 +77,45 @@ class JsonMatcher extends Matcher
     private function transformPattern($pattern)
     {
         return preg_replace(self::TRANSFORM_QUOTATION_PATTERN, self::TRANSFORM_QUOTATION_REPLACEMENT, $pattern);
+    }
+
+    /**
+     * Choose between strict or non strict matching
+     *
+     * @param $value
+     * @param $pattern
+     * @param $matches
+     * @return bool
+     */
+    private function doMatch($value, $pattern, $nonStrictMatching)
+    {
+        if ($nonStrictMatching) {
+            if (is_null($this->nonStrictMatcher)) {
+                throw new Exception(sprintf("There is not any NonStrictMatcher available. Please include it during the constuction of the class %s", __FILE__));
+            }
+
+            return $this->nonStrictMatcher->match($value, $pattern);
+        }
+
+        return $this->matcher->match($value, $pattern);
+    }
+
+    /**
+     * @param $pattern
+     * @return int
+     */
+    protected function isNonStrict($pattern)
+    {
+        return preg_match(self::IGNORE_EXTRA_KEYS_PATTERN, $pattern);
+    }
+
+    /**
+     * @param $pattern
+     * @return string
+     */
+    protected function removeNonStrictPattern($pattern)
+    {
+        return str_replace(self::IGNORE_EXTRA_KEYS_PATTERN, "", $pattern);
     }
 
 }

--- a/src/Coduo/PHPMatcher/Matcher/NonStrictArrayMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/NonStrictArrayMatcher.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher;
+
+use Coduo\PHPMatcher\Parser;
+
+class NonStrictArrayMatcher extends ArrayMatcher
+{
+    /**
+     * @param  array $values
+     * @param  array $patterns
+     * @param string $parentPath
+     * @return bool
+     */
+    protected  function iterateMatch(array $values, array $patterns, $parentPath = "")
+    {
+        $pattern = null;
+        foreach ($values as $key => $value) {
+            $path = $this->formatAccessPath($key);
+
+            if ($this->shouldSkippValueMatchingFor($pattern)) {
+                continue;
+            }
+
+            if ($this->valueExist($path, $patterns)) {
+                $pattern = $this->getValueByPath($patterns, $path);
+            } else {
+                continue;
+            }
+
+            if ($this->shouldSkippValueMatchingFor($pattern)) {
+                continue;
+            }
+
+            if ($this->valueMatchPattern($value, $pattern)) {
+                continue;
+            }
+
+            if (!is_array($value) || !$this->canMatch($pattern)) {
+                return false;
+            }
+
+            if ($this->isArrayPattern($pattern)) {
+                if (!$this->allExpandersMatch($value, $pattern)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (false === $this->iterateMatch($value, $pattern, $this->formatFullPath($parentPath, $path))) {
+                return false;
+            }
+        }
+
+        if (!$this->isPatternValid($patterns, $values, $parentPath)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/NonStrictArrayMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/NonStrictArrayMatcherTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher;
+
+use Coduo\PHPMatcher\Lexer;
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Parser;
+
+class NonStrictArrayMatcherTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Matcher\ArrayMatcher
+     */
+    private $matcher;
+
+    public function setUp()
+    {
+        $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
+        $this->matcher = new Matcher\NonStrictArrayMatcher(
+            new Matcher\ChainMatcher(array(
+                new Matcher\CallbackMatcher(),
+                new Matcher\ExpressionMatcher(),
+                new Matcher\NullMatcher(),
+                new Matcher\StringMatcher($parser),
+                new Matcher\IntegerMatcher($parser),
+                new Matcher\BooleanMatcher(),
+                new Matcher\DoubleMatcher($parser),
+                new Matcher\NumberMatcher(),
+                new Matcher\ScalarMatcher(),
+                new Matcher\WildcardMatcher(),
+            )),
+            $parser
+        );
+    }
+
+    /**
+     * @dataProvider positiveMatchData
+     */
+    public function test_positive_match_arrays($value, $pattern)
+    {
+        $this->assertTrue($this->matcher->match($value, $pattern));
+    }
+
+    /**
+     * @dataProvider negativeMatchData
+     */
+    public function test_negative_match_arrays($value, $pattern)
+    {
+        $this->assertFalse($this->matcher->match($value, $pattern));
+    }
+
+    public function test_negative_match_when_cant_find_matcher_that_can_match_array_element()
+    {
+        $matcher = new Matcher\ArrayMatcher(
+            new Matcher\ChainMatcher(array(
+                new Matcher\WildcardMatcher()
+            )),
+            $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer())
+        );
+
+        $this->assertFalse($matcher->match(array('test' => 1), array('test' => 1)));
+    }
+
+    public function test_error_when_path_in_pattern_does_not_exist()
+    {
+        $this->assertFalse($this->matcher->match(array('foo' => 'foo value'), array('bar' => 'bar value')));
+        $this->assertEquals($this->matcher->getError(), 'There is no element under path [bar] in value.');
+    }
+
+    public function test_error_when_path_in_nested_pattern_does_not_exist()
+    {
+        $array = array('foo' => array('bar' => array('baz' => 'bar value')));
+        $pattern = array('foo' => array('bar' => array('faz' => 'faz value')));
+
+        $this->assertFalse($this->matcher->match($array,$pattern));
+
+        $this->assertEquals($this->matcher->getError(), 'There is no element under path [foo][bar][faz] in value.');
+    }
+
+    public function test_error_when_path_in_value_does_not_exist()
+    {
+        $array = array('foo' => 'foo');
+        $pattern = array('foo' => 'foo', 'bar' => 'bar');
+
+        $this->assertFalse($this->matcher->match($array, $pattern));
+
+        $this->assertEquals($this->matcher->getError(), 'There is no element under path [bar] in value.');
+    }
+
+    public function test_error_when_path_in_nested_value_does_not_exist()
+    {
+        $array = array('foo' => array('bar' => array()));
+        $pattern = array('foo' => array('bar' => array('faz' => 'faz value')));
+
+        $this->assertFalse($this->matcher->match($array, $pattern));
+
+        $this->assertEquals($this->matcher->getError(), 'There is no element under path [foo][bar][faz] in value.');
+    }
+
+    public function test_error_when_matching_fail()
+    {
+        $this->assertFalse($this->matcher->match(array('foo' => 'foo value'), array('foo' => 'bar value')));
+        $this->assertEquals($this->matcher->getError(), '"foo value" does not match "bar value".');
+    }
+
+    public function test_error_message_when_matching_non_array_value()
+    {
+        $this->assertFalse($this->matcher->match(new \DateTime(), "@array@"));
+        $this->assertEquals($this->matcher->getError(), "object \"\\DateTime\" is not a valid array.");
+    }
+
+    public function test_matching_array_to_array_pattern()
+    {
+        $this->assertTrue($this->matcher->match(array("foo", "bar"), "@array@"));
+        $this->assertTrue($this->matcher->match(array("foo"), "@array@.inArray(\"foo\")"));
+        $this->assertTrue($this->matcher->match(
+            array("foo", array("bar")),
+            array(
+                "@string@",
+                "@array@.inArray(\"bar\")"
+            )
+        ));
+    }
+
+    public static function positiveMatchData()
+    {
+        $simpleArr =  array(
+            'users' => array(
+                array(
+                    'firstName' => 'Norbert',
+                    'lastName' => 'Orzechowicz'
+                ),
+                array(
+                    'firstName' => 'Michał',
+                    'lastName' => 'Dąbrowski'
+                )
+            ),
+            true,
+            false,
+            1,
+            6.66
+        );
+
+        $simpleArrPattern =  array(
+            'users' => array(
+                array(
+                    'firstName' => '@string@',
+                    'lastName' => '@string@'
+                ),
+                '@...@'
+            ),
+            true,
+            false,
+            1,
+            6.66
+        );
+
+        return array(
+            array($simpleArr, $simpleArr),
+            array($simpleArr, $simpleArrPattern),
+            array(array(), array()),
+            array(array('key' => 'val'), array('key' => 'val')),
+            array(array(1), array(1)),
+            array(array('roles' => array('ROLE_ADMIN', 'ROLE_DEVELOPER')), array('roles' => '@wildcard@')),
+            array(
+                array('key' => 'val', 'arr' => array('buz' => 'zub', 'subarr' => 'val')),
+                array('key' => 'val', 'arr' => array('subarr' => 'val'))
+            )
+        );
+    }
+
+    public static function negativeMatchData()
+    {
+        $simpleArr =  array(
+            'users' => array(
+                array(
+                    'firstName' => 'Norbert',
+                    'lastName' => 'Orzechowicz'
+                ),
+                array(
+                    'firstName' => 'Michał',
+                    'lastName' => 'Dąbrowski'
+                )
+            ),
+            true,
+            false,
+            1,
+            6.66
+        );
+
+        $simpleDiff =  array(
+            'users' => array(
+                array(
+                    'firstName' => 'Norbert',
+                    'lastName' => 'Orzechowicz'
+                ),
+                array(
+                    'firstName' => 'Pablo',
+                    'lastName' => 'Dąbrowski'
+                )
+            ),
+            true,
+            false,
+            1,
+            6.66
+        );
+
+        return array(
+            array($simpleArr, $simpleDiff),
+            array(array('key' => 'val'), array('key' => 'val2')),
+            array(array(1), array(2)),
+            array(array('foo', 1, 3), array('foo', 2, 3)),
+            array(array(), array('foo' => 'bar')),
+            array(array('foo' => 'val'), array('bar' => 'val')),
+            array(
+                array('foo' => 'val', 'buzz' => array('key' => 'val')),
+                array('foo' => 'val', 'buzz' => array('dam' => 'fal'))
+            )
+        );
+    }
+}


### PR DESCRIPTION
After studying a bit issue #39 , I found out that the only thing required to be able to match softly a JSON, would be having a new `ArrayMatcher`, being able to keep going through the array instead of returning an error when there is a value not contained in the pattern.
So here it is my proposal of creating a new `NonStrictArrayMatcher`, a subtype of the `ArrayMatcher`, where only changes the `iterateMatch()` method.

So, to get what I requested on issue #39 it would be only needed to create a `JsonMatcher` containing a `NonStrictArrayMatcher`.