### PR TITLE
Add casting to bool for expression regex matches

### DIFF
--- a/src/Coduo/PHPMatcher/Matcher/ExpressionMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/ExpressionMatcher.php
@@ -22,7 +22,7 @@ class ExpressionMatcher extends Matcher
             $this->error = sprintf("\"%s\" expression fails for value \"%s\".", $pattern, new String($value));
         }
 
-        return $expressionResult;
+        return (bool) $expressionResult;
     }
 
     /**

--- a/tests/Coduo/PHPMatcher/Matcher/ExpressionMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/ExpressionMatcherTest.php
@@ -51,6 +51,24 @@ class ExpressionMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($error, $matcher->getError());
     }
 
+    /**
+     * @dataProvider positiveRegexMatchData
+     */
+    public function test_positive_regex_matches($value, $pattern)
+    {
+        $matcher = new ExpressionMatcher();
+        $this->assertTrue($matcher->match($value, $pattern));
+    }
+
+    /**
+     * @dataProvider negativeRegexMatchData
+     */
+    public function test_negative_regex_matches($value, $pattern)
+    {
+        $matcher = new ExpressionMatcher();
+        $this->assertFalse($matcher->match($value, $pattern));
+    }
+
     public static function positiveCanMatchData()
     {
         return array(
@@ -96,6 +114,22 @@ class ExpressionMatcherTest extends \PHPUnit_Framework_TestCase
                 "expr(value.format('Y-m-d') == '2014-04-02')",
                 "\"expr(value.format('Y-m-d') == '2014-04-02')\" expression fails for value \"\\DateTime\"."
             ),
+        );
+    }
+
+    public static function positiveRegexMatchData()
+    {
+        return array(
+            array('Cakper', 'expr(value matches "/Cakper/")'),
+            array('Cakper', 'expr(not(value matches "/Yaboomaster/"))'),
+        );
+    }
+
+    public static function negativeRegexMatchData()
+    {
+        return array(
+            array('Cakper', 'expr(not(value matches "/Cakper/"))'),
+            array('Cakper', 'expr(value matches "/Yaboomaster/")'),
         );
     }
 }


### PR DESCRIPTION
Evaluating regular expressions returns number of matches (so 1 if exact match exists) and matcher is using strict comparison === in order to evaluate such value. 

Simple casting to boolean fixes the problem.
