### PR TITLE
Added text matcher

### DIFF
--- a/src/Coduo/PHPMatcher/AST/Pattern.php
+++ b/src/Coduo/PHPMatcher/AST/Pattern.php
@@ -24,7 +24,7 @@ class Pattern implements Node
     }
 
     /**
-     * @return mixed
+     * @return Type
      */
     public function getType()
     {

--- a/src/Coduo/PHPMatcher/Exception/UnknownTypeException.php
+++ b/src/Coduo/PHPMatcher/Exception/UnknownTypeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Coduo\PHPMatcher\Exception;
+
+class UnknownTypeException extends Exception
+{
+}

--- a/src/Coduo/PHPMatcher/Factory/SimpleFactory.php
+++ b/src/Coduo/PHPMatcher/Factory/SimpleFactory.php
@@ -29,7 +29,8 @@ class SimpleFactory implements Factory
             $scalarMatchers,
             $arrayMatcher,
             new Matcher\JsonMatcher($arrayMatcher),
-            new Matcher\XmlMatcher($arrayMatcher)
+            new Matcher\XmlMatcher($arrayMatcher),
+            new Matcher\TextMatcher($scalarMatchers, $this->buildParser())
         ));
     }
 

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/GreaterThan.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/Expander/GreaterThan.php
@@ -35,7 +35,7 @@ class GreaterThan implements PatternExpander
      */
     public function match($value)
     {
-        if (!is_float($value) && !is_integer($value) && !is_double($value)) {
+        if (!is_float($value) && !is_integer($value) && !is_double($value) && !is_numeric($value)) {
             $this->error = sprintf("Value \"%s\" is not a valid number.", new String($value));
             return false;
         }

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/RegexConverter.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/RegexConverter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern;
+
+use Coduo\PHPMatcher\Exception\UnknownTypeException;
+
+class RegexConverter
+{
+    public function toRegex(TypePattern $type)
+    {
+        switch ($type->getType()) {
+            case 'string':
+            case 'wildcard':
+            case '*':
+                return "(.+)";
+            case 'number':
+                return "(\\-?[0-9]*[\\.|\\,]?[0-9]*)";
+            case 'integer':
+                return "(\\-?[0-9]*)";
+            case 'double':
+                return "(\\-?[0-9]*[\\.|\\,][0-9]*)";
+            default:
+                throw new UnknownTypeException();
+        }
+    }
+}

--- a/src/Coduo/PHPMatcher/Matcher/Pattern/TypePattern.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/TypePattern.php
@@ -38,6 +38,14 @@ class TypePattern implements Pattern
     }
 
     /**
+     * @return string
+     */
+    public function getType()
+    {
+        return strtolower($this->type);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function addExpander(PatternExpander $expander)

--- a/src/Coduo/PHPMatcher/Matcher/TextMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/TextMatcher.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher;
+
+use Coduo\PHPMatcher\Matcher\Pattern\TypePattern;
+use Coduo\PHPMatcher\Parser;
+use Coduo\PHPMatcher\Matcher\Pattern\RegexConverter;
+use Coduo\ToString\String;
+
+class TextMatcher extends Matcher
+{
+    const PATTERN_REGEXP = "/@[a-zA-Z\\.]+@(\\.[a-zA-Z0-9_]+\\([a-zA-Z0-9{},:@\\.\"'\\(\\)]*\\))*/";
+
+    const PATTERN_REGEXP_PLACEHOLDER_TEMPLATE = "__PLACEHOLDER%d__";
+
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    /**
+     * @var ValueMatcher
+     */
+    private $matcher;
+
+    /**
+     * @param ValueMatcher $matcher
+     * @param Parser $parser
+     */
+    public function __construct(ValueMatcher $matcher, Parser $parser)
+    {
+        $this->parser = $parser;
+        $this->matcher = $matcher;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function match($value, $pattern)
+    {
+        if (!is_string($value)) {
+            $this->error = sprintf("%s \"%s\" is not a valid string.", gettype($value), new String($value));
+            return false;
+        }
+
+        $patternRegex = $pattern;
+        $patternsReplacedWithRegex = $this->replaceTypePatternsWithPlaceholders($patternRegex);
+        $patternRegex = $this->prepareRegex($patternRegex);
+        $patternRegex = $this->replacePlaceholderWithPatternRegexes($patternRegex, $patternsReplacedWithRegex);
+
+        if (!preg_match($patternRegex, $value, $matchedValues)) {
+            $this->error = sprintf("\"%s\" does not match \"%s\" pattern", $value, $pattern);
+            return false;
+        }
+
+        array_shift($matchedValues); // remove matched string
+
+        if (count($patternsReplacedWithRegex) !== count($matchedValues)) {
+            $this->error = "Unexpected TextMatcher error.";
+            return false;
+        }
+
+        foreach ($patternsReplacedWithRegex as $index => $typePattern) {
+            if (!$typePattern->matchExpanders($matchedValues[$index])) {
+                $this->error = $typePattern->getError();
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function canMatch($pattern)
+    {
+        if (!is_string($pattern)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Reaplce each type pattern (@string@.startsWith("lorem")) with placeholder, in order
+     * to use preg_quote without destroying pattern & expanders.
+     *
+     * before replacement: "/users/@integer@.greaterThan(200)/active"
+     * after replacement:  "/users/__PLACEHOLDER0__/active"
+     *
+     * @param string $patternRegex
+     * @return TypePattern[]|array
+     */
+    private function replaceTypePatternsWithPlaceholders(&$patternRegex)
+    {
+        $patternsReplacedWithRegex = array();
+        preg_match_all(self::PATTERN_REGEXP, $patternRegex, $matches);
+
+        foreach ($matches[0] as $index => $typePatternString) {
+            $typePattern = $this->parser->parse($typePatternString);
+            $patternsReplacedWithRegex[] = $typePattern;
+            $patternRegex = str_replace(
+                $typePatternString,
+                sprintf(self::PATTERN_REGEXP_PLACEHOLDER_TEMPLATE, $index),
+                $patternRegex
+            );
+        }
+
+        return $patternsReplacedWithRegex;
+    }
+
+
+    /**
+     * Replace placeholders with type pattern regular expressions
+     * before replacement: "/users/__PLACEHOLDER0__/active"
+     * after replacement:  "/^\/users\/(\-?[0-9]*)\/active$/"
+     *
+     * @param $patternRegex
+     * @return string
+     * @throws \Coduo\PHPMatcher\Exception\UnknownTypeException
+     */
+    private function replacePlaceholderWithPatternRegexes($patternRegex, array $patternsReplacedWithRegex)
+    {
+        $regexConverter = new RegexConverter();
+        foreach ($patternsReplacedWithRegex as $index => $typePattern) {
+            $patternRegex = str_replace(
+                sprintf(self::PATTERN_REGEXP_PLACEHOLDER_TEMPLATE, $index),
+                $regexConverter->toRegex($typePattern),
+                $patternRegex
+            );
+        }
+
+        return $patternRegex;
+    }
+
+    /**
+     * Prepare regular expression
+     *
+     * @param string $patternRegex
+     * @return string
+     */
+    private function prepareRegex($patternRegex)
+    {
+        return "/^" . preg_quote($patternRegex, '/') . "$/";
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/GreaterThanTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/Pattern/Expander/GreaterThanTest.php
@@ -23,6 +23,7 @@ class GreaterThanTest extends \PHPUnit_Framework_TestCase
             array(-20, -10.5, true),
             array(10, 1, false),
             array(1, 1, false),
+            array(10, "20", true)
         );
     }
 

--- a/tests/Coduo/PHPMatcher/Matcher/Pattern/RegexConverterTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/Pattern/RegexConverterTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern;
+
+use Coduo\PHPMatcher\Matcher\Pattern\TypePattern;
+use Coduo\PHPMatcher\Matcher\Pattern\RegexConverter;
+
+class RegexConverterTest  extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RegexConverter
+     */
+    private $converter;
+
+    public function setUp()
+    {
+        $this->converter = new RegexConverter();
+    }
+
+    /**
+     * @expectedException \Coduo\PHPMatcher\Exception\UnknownTypeException
+     */
+    public function test_convert_unknown_type()
+    {
+        $this->converter->toRegex(new TypePattern("not_a_type"));
+    }
+}

--- a/tests/Coduo/PHPMatcher/Matcher/TextMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/TextMatcherTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher;
+
+use Coduo\PHPMatcher\Lexer;
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Parser;
+
+class TextMatcherTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Matcher\TextMatcher
+     */
+    private $matcher;
+
+    public function setUp()
+    {
+        $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
+        $scalarMatchers = new Matcher\ChainMatcher(array(
+            new Matcher\CallbackMatcher(),
+            new Matcher\ExpressionMatcher(),
+            new Matcher\NullMatcher(),
+            new Matcher\StringMatcher($parser),
+            new Matcher\IntegerMatcher($parser),
+            new Matcher\BooleanMatcher(),
+            new Matcher\DoubleMatcher($parser),
+            new Matcher\NumberMatcher(),
+            new Matcher\ScalarMatcher(),
+            new Matcher\WildcardMatcher(),
+        ));
+        $this->matcher = new Matcher\TextMatcher(
+            new Matcher\ChainMatcher(array(
+                $scalarMatchers,
+                new Matcher\ArrayMatcher($scalarMatchers, $parser)
+            )),
+            $parser
+        );
+    }
+
+    /**
+     * @dataProvider matchingData
+     */
+    public function test_positive_matches($value, $pattern, $expectedResult)
+    {
+        $this->assertEquals($expectedResult, $this->matcher->match($value, $pattern));
+    }
+
+    public function matchingData()
+    {
+        return array(
+            array(
+                "lorem ipsum lol lorem 24 dolorem",
+                "lorem ipsum @string@.startsWith(\"lo\") lorem @number@ dolorem",
+                true
+            ),
+            array(
+                "lorem ipsum 24 dolorem",
+                "lorem ipsum @integer@",
+                false
+            ),
+            array(
+                "/users/12345/active",
+                "/users/@integer@.greaterThan(0)/active",
+                true
+            )
+        );
+    }
+}

--- a/tests/Coduo/PHPMatcher/MatcherTest.php
+++ b/tests/Coduo/PHPMatcher/MatcherTest.php
@@ -41,7 +41,8 @@ class MatcherTest extends \PHPUnit_Framework_TestCase
             $scalarMatchers,
             $arrayMatcher,
             new Matcher\JsonMatcher($arrayMatcher),
-            new Matcher\XmlMatcher($arrayMatcher)
+            new Matcher\XmlMatcher($arrayMatcher),
+            new Matcher\TextMatcher($scalarMatchers, $parser)
         )));
     }
 
@@ -192,6 +193,14 @@ XML;
 
         $this->assertTrue($this->matcher->match($xml, $xmlPattern));
         $this->assertTrue(match($xml, $xmlPattern));
+    }
+
+    public function test_text_matcher()
+    {
+        $value = "lorem ipsum 1234 random text";
+        $pattern = "@string@.startsWith('lo') ipsum @number@.greaterThan(10) random text";
+        $this->assertTrue($this->matcher->match($value, $pattern));
+        $this->assertTrue(match($value, $pattern));
     }
 
     public function test_matcher_with_captures()


### PR DESCRIPTION
After merge it will possible to match texts that include type patterns.
Example: 

``` php
use Coduo\PHPMatcher\Factory\SimpleFactory;

$factory = new SimpleFactory();
$matcher = $factory->createMatcher();

$match = $matcher->match("/users/1245/active", "/users/@integer@.greaterThan(0)/active")
```
