### PR TITLE
TextMatcher should not match @null@ inside pattern

### DIFF
--- a/src/Coduo/PHPMatcher/Matcher/TextMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/TextMatcher.php
@@ -79,6 +79,10 @@ class TextMatcher extends Matcher
             return false;
         }
 
+        if (mb_strlen($pattern) !== 6 && false !== mb_strpos($pattern, '@null@')) {
+            return false;
+        }
+
         return true;
     }
 

--- a/tests/Coduo/PHPMatcher/Matcher/TextMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/TextMatcherTest.php
@@ -37,6 +37,20 @@ class TextMatcherTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function test_can_match_general_strings()
+    {
+        $this->assertTrue($this->matcher->canMatch(''));
+        $this->assertTrue($this->matcher->canMatch('String with text'));
+        $this->assertTrue($this->matcher->canMatch('String with text, @number@ and @*@'));
+    }
+
+    public function test_cannot_match_null_as_part_of_pattern()
+    {
+        $this->assertFalse($this->matcher->canMatch("Using @null@ inside other text"));
+        $this->assertFalse($this->matcher->canMatch("@null@ at start of pattern"));
+        $this->assertFalse($this->matcher->canMatch("pattern ends with @null@"));
+    }
+
     /**
      * @dataProvider matchingData
      */


### PR DESCRIPTION
The `TextMatcher` currently reports that it matches against all strings. During matching against strings with `@null@` in them an `UnknownTypeException` will be thrown - after all a pattern like `this should be @null@` makes no sense in a text context. 

This prevents other matchers from being able to match, so I've changed it to not match in this case. 

Reproduce code: 

```php
<?php

use Coduo\PHPMatcher\Factory\SimpleFactory;

require_once __DIR__ . '/vendor/autoload.php';

$expected = <<<JSON
{
    "a": @null@,
    "b": 4
}
JSON;


$actual = <<<JSON
{
    "a": null,
    "b": 5
}
JSON;


$matcher = (new SimpleFactory())->createMatcher();


echo $matcher->match($actual, $expected)
    ? 'Match found' :
    'Match not found: ' . $matcher->getError()
;
```