### PR TITLE
Missing type in RegexConverter

### DIFF
--- a/src/Coduo/PHPMatcher/Matcher/Pattern/RegexConverter.php
+++ b/src/Coduo/PHPMatcher/Matcher/Pattern/RegexConverter.php
@@ -19,6 +19,8 @@ class RegexConverter
                 return "(\\-?[0-9]*)";
             case 'double':
                 return "(\\-?[0-9]*[\\.|\\,][0-9]*)";
+            case 'null':
+                return "(null|NULL)";
             default:
                 throw new UnknownTypeException();
         }


### PR DESCRIPTION
We have used type null, and after update to 1.1.4 we get an Exception.