### PR TITLE
CallbackMatcher should not be executed for internal function names

### DIFF
--- a/src/Coduo/PHPMatcher/Matcher/CallbackMatcher.php
+++ b/src/Coduo/PHPMatcher/Matcher/CallbackMatcher.php
@@ -17,6 +17,6 @@ class CallbackMatcher extends Matcher
      */
     public function canMatch($pattern)
     {
-        return is_callable($pattern);
+        return is_object($pattern) && is_callable($pattern);
     }
 }

--- a/tests/Coduo/PHPMatcher/Matcher/CallbackMatcherTest.php
+++ b/tests/Coduo/PHPMatcher/Matcher/CallbackMatcherTest.php
@@ -15,6 +15,7 @@ class CallbackMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $matcher = new CallbackMatcher();
         $this->assertFalse($matcher->canMatch(new \DateTime()));
+        $this->assertFalse($matcher->canMatch('SIN'));
     }
 
     function test_positive_matches()


### PR DESCRIPTION
I found a problem with CallbackMatcher - it was executed for strings representing internal function names, like sin.

There is a small fix, that prevents execution of callbackMatcher on non-objects.