### PR TITLE
the Content had been duplicated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ $match = $matcher->match("lorem ipsum dolor", "@string@")
 * ``@boolean@``
 * ``@array@``
 * ``@...@`` - *unbounded array*
-* ``@double@``
 * ``@null@``
 * ``@*@`` || ``@wildcard@``
 * ``expr(expression)``


### PR DESCRIPTION
`@double@` had been duplicated.