### PR TITLE
PHPUnit integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,37 @@ Feature: Listing user toys
     """
 ``` 
 
+## PHPUnit integration
+
+The `assertMatchesPattern()` is a handy assertion that matches values in PHPUnit tests.
+To use it either include the `Coduo\PHPMatcher\PHPUnit\PHPMatcherAssertions` trait,
+or extend the `Coduo\PHPMatcher\PHPUnit\PHPMatcherTestCase`:
+
+```php
+namespace Coduo\PHPMatcher\Tests\PHPUnit;
+
+use Coduo\PHPMatcher\PHPUnit\PHPMatcherAssertions;
+
+class PHPMatcherAssertionsTest extends \PHPUnit_Framework_TestCase
+{
+    use PHPMatcherAssertions;
+
+    public function test_it_asserts_if_a_value_matches_the_pattern()
+    {
+        $this->assertMatchesPattern('@string@', 'foo');
+    }
+}
+```
+
+The `matchesPattern()` method can be used in PHPUnit stubs or mocks:
+
+```php
+$mock = $this->getMock(Foo::class);
+$mock->method('bar')
+    ->with($this->matchesPattern('@string@'))
+    ->willReturn('foo');
+```
+
 ## License
 
 This library is distributed under the MIT license. Please see the LICENSE file.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,11 +13,13 @@
     <testsuites>
         <testsuite name="PHP Matcher Test Suite">
             <directory>./tests/</directory>
+            <exclude>tests/PHPUnit/PHPMatcherAssertionsTest.php</exclude>
+            <file phpVersion="5.4.0" phpVersionOperator=">=">tests/PHPUnit/PHPMatcherAssertionsTest.php</file>
         </testsuite>
     </testsuites>
     <filter>
         <whitelist>
-            <directory>./src/Coduo/PHPMatcher/</directory>
+            <directory>./src/</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/PHPUnit/PHPMatcherAssertions.php
+++ b/src/PHPUnit/PHPMatcherAssertions.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Coduo\PHPMatcher\PHPUnit;
+
+trait PHPMatcherAssertions
+{
+    /**
+     * @param string $pattern
+     * @param mixed  $value
+     * @param string $message
+     */
+    protected function assertMatchesPattern($pattern, $value, $message = '')
+    {
+        \PHPUnit_Framework_TestCase::assertThat($value, self::matchesPattern($pattern), $message);
+    }
+
+    /**
+     * @param string $pattern
+     *
+     * @return PHPMatcherConstraint
+     */
+    protected static function matchesPattern($pattern)
+    {
+        return new PHPMatcherConstraint($pattern);
+    }
+}

--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Coduo\PHPMatcher\PHPUnit;
+
+use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Matcher;
+
+final class PHPMatcherConstraint extends \PHPUnit_Framework_Constraint
+{
+    /**
+     * @var string
+     */
+    private $pattern;
+
+    /**
+     * @var Matcher
+     */
+    private $matcher;
+
+    /**
+     * @param string $pattern
+     */
+    public function __construct($pattern)
+    {
+        parent::__construct();
+
+        $this->pattern = $pattern;
+        $this->matcher = $this->createMatcher();
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
+        return 'matches the pattern';
+    }
+
+    /**
+     * @param mixed $other
+     *
+     * @return null|string
+     */
+    protected function additionalFailureDescription($other)
+    {
+        return $this->matcher->getError();
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    protected function matches($value)
+    {
+        return $this->matcher->match($value, $this->pattern);
+    }
+
+    /**
+     * @return Matcher
+     */
+    private function createMatcher()
+    {
+        $factory = new SimpleFactory();
+
+        return $factory->createMatcher();
+    }
+}

--- a/src/PHPUnit/PHPMatcherTestCase.php
+++ b/src/PHPUnit/PHPMatcherTestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Coduo\PHPMatcher\PHPUnit;
+
+abstract class PHPMatcherTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $pattern
+     * @param mixed  $value
+     * @param string $message
+     */
+    protected function assertMatchesPattern($pattern, $value, $message = '')
+    {
+        $this->assertThat($value, self::matchesPattern($pattern), $message);
+    }
+
+    /**
+     * @param string $pattern
+     *
+     * @return PHPMatcherConstraint
+     */
+    protected static function matchesPattern($pattern)
+    {
+        return new PHPMatcherConstraint($pattern);
+    }
+}

--- a/tests/PHPUnit/PHPMatcherAssertionsTest.php
+++ b/tests/PHPUnit/PHPMatcherAssertionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\PHPUnit;
+
+use Coduo\PHPMatcher\PHPUnit\PHPMatcherAssertions;
+
+class PHPMatcherAssertionsTest extends \PHPUnit_Framework_TestCase
+{
+    use PHPMatcherAssertions;
+
+    public function test_it_asserts_if_a_value_matches_the_pattern()
+    {
+        $this->assertMatchesPattern('@string@', 'foo');
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage Failed asserting that '{"foo":"bar"}' matches the pattern
+     */
+    public function test_it_throws_an_expectation_failed_exception_if_a_value_does_not_match_the_pattern()
+    {
+        $this->assertMatchesPattern('{"foo": "@integer@"}', json_encode(array('foo' => 'bar')));
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage Failed asserting that 42 matches the pattern.
+     */
+    public function test_it_creates_a_constraint_for_stubs()
+    {
+        $mock = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getTitle'))
+            ->getMock();
+
+        $mock->method('getTitle')
+            ->with($this->matchesPattern('@string@'))
+            ->willReturn('foo');
+
+        $mock->getTitle(42);
+    }
+}

--- a/tests/PHPUnit/PHPMatcherConstraintTest.php
+++ b/tests/PHPUnit/PHPMatcherConstraintTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\PHPUnit;
+
+use Coduo\PHPMatcher\PHPUnit\PHPMatcherConstraint;
+
+class PHPMatcherConstraintTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_it_is_a_phpunit_constraint()
+    {
+        $this->assertInstanceOf('PHPUnit_Framework_Constraint', new PHPMatcherConstraint('@string@'));
+    }
+
+    public function test_it_returns_true_if_a_value_matches_the_pattern()
+    {
+        $constraint = new PHPMatcherConstraint('@string@');
+
+        $this->assertTrue($constraint->evaluate('foo', '', true));
+    }
+
+    public function test_it_returns_false_if_a_value_does_not_match_the_pattern()
+    {
+        $constraint = new PHPMatcherConstraint('@string@');
+
+        $this->assertFalse($constraint->evaluate(42, '', true));
+    }
+
+    public function test_it_returns_false_if_a_pattern_is_not_a_string()
+    {
+        $constraint = new PHPMatcherConstraint(new \stdClass());
+
+        $this->assertFalse($constraint->evaluate('foo', '', true));
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage Failed asserting that 42 matches the pattern
+     */
+    public function test_it_sets_a_failure_description_if_not_given()
+    {
+        $constraint = new PHPMatcherConstraint('@string@');
+
+        $this->assertFalse($constraint->evaluate(42));
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage integer "42" is not a valid string
+     */
+    public function test_it_sets_additional_failure_description()
+    {
+        $constraint = new PHPMatcherConstraint('@string@');
+
+        $this->assertFalse($constraint->evaluate(42));
+    }
+}

--- a/tests/PHPUnit/PHPMatcherTestCaseTest.php
+++ b/tests/PHPUnit/PHPMatcherTestCaseTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\PHPUnit;
+
+use Coduo\PHPMatcher\PHPUnit\PHPMatcherTestCase;
+
+class PHPMatcherTestCaseTest extends PHPMatcherTestCase
+{
+    public function test_it_asserts_if_a_value_matches_the_pattern()
+    {
+        $this->assertMatchesPattern('@string@', 'foo');
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage Failed asserting that '{"foo":"bar"}' matches the pattern
+     */
+    public function test_it_throws_an_expectation_failed_exception_if_a_value_does_not_match_the_pattern()
+    {
+        $this->assertMatchesPattern('{"foo": "@integer@"}', json_encode(array('foo' => 'bar')));
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage Failed asserting that 42 matches the pattern.
+     */
+    public function test_it_creates_a_constraint_for_stubs()
+    {
+        $mock = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getTitle'))
+            ->getMock();
+
+        $mock->method('getTitle')
+            ->with($this->matchesPattern('@string@'))
+            ->willReturn('foo');
+
+        $mock->getTitle(42);
+    }
+}


### PR DESCRIPTION
Should allow to do the following in phpunit tests:

```php
class FooTest extends \PHPUnit_Framework_TestCase
{
    use PHPMatcherAssertions;

    public function test_it_asserts_if_a_value_matches_the_pattern()
    {
        $this->assertMatchesPattern('@integer@', 'foo');
    }
}
```
```
Failed asserting that 'foo' matches the pattern.
"foo" does not match "@integer@" pattern
```
For PHP 5.3 `PHPMatcherTestCase` is provided.


