### PR TITLE
Remove redundant configurations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-    backupStaticAttributes="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    syntaxCheck="false"
-    bootstrap="tests/bootstrap.php"
+    bootstrap="vendor/autoload.php"
     >
     <testsuites>
         <testsuite name="PHP Matcher Test Suite">

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-$loader = require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
These are defaults anyway so there is no reason to clutter the config. There is also no need for the bootstrap file as it only includes the autoloader.