### PR TITLE
Change openlss/lib-array2xml version to >= 0.0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "coduo/php-matcher",
     "type": "library",
     "keywords": ["json", "matcher", "tests"],
-    "license": "MIT", 
+    "license": "MIT",
     "authors": [
         {
             "name": "Michał Dąbrowski",
@@ -18,7 +18,7 @@
         "coduo/php-to-string": "1.0.*",
         "symfony/property-access": "~2.3",
         "symfony/expression-language": "~2.4",
-        "openlss/lib-array2xml": "0.0.9"
+        "openlss/lib-array2xml": "~0.0.9"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Hi,

This PR allow to install php-matcher on project depending on other lib-array2xml version.

I made the PR on 1.0 because the issue is on all branches

What do you think ?