### PR TITLE
incompatible with php 7.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.3.0,<7.0.5",
         "ext-filter": "*",
         "coduo/php-to-string": "^2",
         "symfony/property-access": "^2.3|^3.0",


### PR DESCRIPTION
Hi,

This library is currently incompatible with php 7.0.5 due to https://bugs.php.net/bug.php?id=71964.

The function `Coduo\PHPMatcher\Lexer::getType` function needs rewriting somehow (it's not obvious how, exactly) if you want to avoid the bug.

Cheers