### PR TITLE
Add ext-intl as a require-dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "openlss/lib-array2xml": "~0.0.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "ext-intl": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Lack of `ext-intl` breaks the execution of tests.


```bash
➜  php-matcher git:(master) ./bin/phpunit    
PHPUnit 4.8.26 by Sebastian Bergmann and contributors.

...............................................................  63 / 422 ( 14%)
......PHP Fatal error:  Class 'NumberFormatter' not found in /Users/mateusztracz/Projects/php-matcher/vendor/coduo/php-to-string/src/Coduo/ToString/StringConverter.php on line 70
PHP Stack trace:
PHP   1. {main}() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/phpunit:47
PHP   3. PHPUnit_TextUI_Command->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/TextUI/Command.php:100
PHP   4. PHPUnit_TextUI_TestRunner->doRun() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/TextUI/Command.php:149
PHP   5. PHPUnit_Framework_TestSuite->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:440
PHP   6. PHPUnit_Framework_TestSuite->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestSuite.php:747
PHP   7. PHPUnit_Framework_TestSuite->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestSuite.php:747
PHP   8. PHPUnit_Framework_TestCase->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestSuite.php:747
PHP   9. PHPUnit_Framework_TestResult->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestCase.php:724
PHP  10. PHPUnit_Framework_TestCase->runBare() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestResult.php:612
PHP  11. PHPUnit_Framework_TestCase->runTest() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestCase.php:768
PHP  12. ReflectionMethod->invokeArgs() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestCase.php:909
PHP  13. Coduo\PHPMatcher\Tests\Matcher\BooleanMatcherTest->test_negative_match_description() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestCase.php:909
PHP  14. Coduo\PHPMatcher\Matcher\BooleanMatcher->match() /Users/mateusztracz/Projects/php-matcher/tests/Matcher/BooleanMatcherTest.php:50
PHP  15. sprintf() /Users/mateusztracz/Projects/php-matcher/src/Matcher/BooleanMatcher.php:17
PHP  16. Coduo\ToString\StringConverter->__toString() /Users/mateusztracz/Projects/php-matcher/src/Matcher/BooleanMatcher.php:17
PHP  17. Coduo\ToString\StringConverter->castDoubleToString() /Users/mateusztracz/Projects/php-matcher/vendor/coduo/php-to-string/src/Coduo/ToString/StringConverter.php:33

Fatal error: Class 'NumberFormatter' not found in /Users/mateusztracz/Projects/php-matcher/vendor/coduo/php-to-string/src/Coduo/ToString/StringConverter.php on line 70

Call Stack:
    0.0016     230368   1. {main}() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/phpunit:0
    0.0060     661160   2. PHPUnit_TextUI_Command::main() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/phpunit:47
    0.0060     661784   3. PHPUnit_TextUI_Command->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/TextUI/Command.php:100
    0.1536    9300136   4. PHPUnit_TextUI_TestRunner->doRun() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/TextUI/Command.php:149
    0.1580    9494144   5. PHPUnit_Framework_TestSuite->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:440
    0.2101   10597944   6. PHPUnit_Framework_TestSuite->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestSuite.php:747
    0.2156   10680176   7. PHPUnit_Framework_TestSuite->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestSuite.php:747
    0.2160   10683896   8. PHPUnit_Framework_TestCase->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestSuite.php:747
    0.2160   10683896   9. PHPUnit_Framework_TestResult->run() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestCase.php:724
    0.2160   10684904  10. PHPUnit_Framework_TestCase->runBare() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestResult.php:612
    0.2161   10701784  11. PHPUnit_Framework_TestCase->runTest() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestCase.php:768
    0.2161   10702984  12. ReflectionMethod->invokeArgs() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestCase.php:909
    0.2161   10703024  13. Coduo\PHPMatcher\Tests\Matcher\BooleanMatcherTest->test_negative_match_description() /Users/mateusztracz/Projects/php-matcher/vendor/phpunit/phpunit/src/Framework/TestCase.php:909
    0.2161   10703152  14. Coduo\PHPMatcher\Matcher\BooleanMatcher->match() /Users/mateusztracz/Projects/php-matcher/tests/Matcher/BooleanMatcherTest.php:50
    0.2161   10703504  15. sprintf() /Users/mateusztracz/Projects/php-matcher/src/Matcher/BooleanMatcher.php:17
    0.2161   10703800  16. Coduo\ToString\StringConverter->__toString() /Users/mateusztracz/Projects/php-matcher/src/Matcher/BooleanMatcher.php:17
    0.2161   10703968  17. Coduo\ToString\StringConverter->castDoubleToString() /Users/mateusztracz/Projects/php-matcher/vendor/coduo/php-to-string/src/Coduo/ToString/StringConverter.php:33
```

I am not sure whether `intl` is required for running too - I do not know project too well, feel free to discard that PR and add it to the `require` instead of `require-dev`