### PR TITLE
add support for all versions of UUID [1-5]

### DIFF
--- a/src/Matcher/UuidMatcher.php
+++ b/src/Matcher/UuidMatcher.php
@@ -7,7 +7,7 @@ use Coduo\ToString\StringConverter;
 final class UuidMatcher extends Matcher
 {
     const UUID_PATTERN = '/^@uuid@$/';
-    const UUID_FORMAT_PATTERN = '|^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$|';
+    const UUID_FORMAT_PATTERN = '|^[\da-f]{8}-[\da-f]{4}-[1-5][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$|';
 
     /**
      * {@inheritDoc}

--- a/tests/Matcher/UuidMatcherTest.php
+++ b/tests/Matcher/UuidMatcherTest.php
@@ -66,7 +66,11 @@ class UuidMatcherTest extends \PHPUnit_Framework_TestCase
     public static function positiveMatchData()
     {
         return array(
+            array("21627164-acb7-11e6-80f5-76304dec7eb7", "@uuid@"),
+            array("d9c04bc2-173f-2cb7-ad4e-e4ca3b2c273f", "@uuid@"),
+            array("7b368038-a5ca-3aa3-b0db-1177d1761c9e", "@uuid@"),
             array("9f4db639-0e87-4367-9beb-d64e3f42ae18", "@uuid@"),
+            array("1f2b1a18-81a0-5685-bca7-f23022ed7c7b", "@uuid@"),
         );
     }
 


### PR DESCRIPTION
UUID have  [multiple versions](https://en.wikipedia.org/wiki/Universally_unique_identifier#Variants_and_versions]).

For example Mysql use [version 1](http://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_uuid)