### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-#A quick guide to contribute to the project:
+# A quick guide to contribute to the project:
 
-##Installing the dev environment
+## Installing the dev environment
 
 1.  Fork the repo
 2.  Clone the repo to local
@@ -8,7 +8,7 @@
 4.  Run the tests. We only take pull requests with passing tests, and it's great to know that you have a clean slate:
     `./bin/phpunit`
 
-##Coding Standards
+## Coding Standards
 
 Try use similar coding standards to what you see in the project to keep things clear to the contributors. If you're unsure, it's always a safe bet to fall-back to the PSR standards.
 
@@ -16,14 +16,14 @@ Try use similar coding standards to what you see in the project to keep things c
 
 [PSR-2: Coding Style Guide](http://www.php-fig.org/psr/psr-2/)
 
-##Adding new features
+## Adding new features
 
 Pull requests with new features needs to be created against master branch. 
 
 If new feature require BC Breake please note that in your PR comment, it will added in next major version.
 New features that does not have any BC Breakes are going to be added in next minor version.
 
-##Patches and bugfixes 
+## Patches and bugfixes 
 
 1. Check the oldest version that patch/bug fix can be applied.
 2. Create PR against that version 
@@ -31,7 +31,7 @@ New features that does not have any BC Breakes are going to be added in next min
 For example if you are fixing pattern expander that was introduced in version 1.1 make sure that PR with fix 
 is created against version 1.1, not master or 2.0 
 
-##The actual contribution
+## The actual contribution
 
 1.  Make the changes/additions to the code, committing often and making clear what you've done
 2.  Make sure you write tests for your code, located in the folder structure `tests/Coduo/PHPMatcher/...`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PHP Matcher
+# PHP Matcher
 
 ***PHP Matcher*** lets You assert like a gangster in Your test cases, where response can be something you cannot predict
 
@@ -15,7 +15,7 @@
 [Readme for 1.0 version](https://github.com/coduo/php-matcher/tree/1.0/README.md)
 
 
-##Installation
+## Installation
 
 Require new dev dependency using composer (assuming it's installed globally):
 
@@ -84,7 +84,7 @@ $matcher->getError(); // returns null or error message
 * ``oneOf(...$expanders)`` - example usage ``"@string@.oneOf(contains('foo'), contains('bar'), contains('baz'))"``
 * ``matchRegex($regex)`` - example usage ``"@string@.matchRegex('/^lorem.+/')"``
 
-##Example usage
+## Example usage
 
 ### Scalar matching
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
