### PR TITLE
Allow to mark JSON properties & XML nodes as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ $matcher->getError(); // returns null or error message
 * ``inArray($value)``
 * ``oneOf(...$expanders)`` - example usage ``"@string@.oneOf(contains('foo'), contains('bar'), contains('baz'))"``
 * ``matchRegex($regex)`` - example usage ``"@string@.matchRegex('/^lorem.+/')"``
+* ``optional()`` - work's only with ``ArrayMatcher``, ``JsonMatcher`` and ``XmlMatcher``
 
 ##Example usage
 
@@ -237,7 +238,8 @@ $matcher->match(
               'id' => 1,
               'firstName' => 'Norbert',
               'lastName' => 'Orzechowicz',
-              'roles' => array('ROLE_USER')
+              'roles' => array('ROLE_USER'),
+              'position' => 'Developer',
           ),
           array(
               'id' => 2,
@@ -261,7 +263,8 @@ $matcher->match(
               'id' => '@integer@.greaterThan(0)',
               'firstName' => '@string@',
               'lastName' => 'Orzechowicz',
-              'roles' => '@array@'
+              'roles' => '@array@',
+              'position' => '@string@.optional()'
           ),
           array(
               'id' => '@integer@',
@@ -303,7 +306,8 @@ $matcher->match(
         "firstName": @string@,
         "lastName": @string@,
         "created": "@string@.isDateTime()",
-        "roles": @array@
+        "roles": @array@,
+        "posiiton": "@string@.optional()"
       }
     ]
   }'
@@ -347,6 +351,7 @@ XML
   <m:GetStockPrice>
     <m:StockName>@string@</m:StockName>
     <m:StockValue>@string@</m:StockValue>
+    <m:StockQty>@integer@.optional()</m:StockQty>
   </m:GetStockPrice>
 </soap:Body>
 

--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -153,17 +153,40 @@ final class ArrayMatcher extends Matcher
                 }
             );
 
-            $notExistingKeys = array_diff_key($pattern, $values);
-
+            $notExistingKeys = $this->findNotExistingKeys($pattern, $values);
             if (count($notExistingKeys) > 0) {
                 $keyNames = array_keys($notExistingKeys);
                 $path = $this->formatFullPath($parentPath, $this->formatAccessPath($keyNames[0]));
                 $this->setMissingElementInError('value', $path);
+
                 return false;
             }
         }
 
         return true;
+    }
+
+    /**
+     * Finds not existing keys
+     * Excludes keys with pattern which includes Optional Expander
+     *
+     * @param $pattern
+     * @param $values
+     * @return array
+     */
+    private function findNotExistingKeys($pattern, $values)
+    {
+        $notExistingKeys = array_diff_key($pattern, $values);
+
+        return array_filter($notExistingKeys, function ($pattern) use ($values) {
+            try {
+                $typePattern = $this->parser->parse($pattern);
+            } catch (\Exception $e) {
+                return true;
+            }
+
+            return !$typePattern->hasExpander('optional');
+        });
     }
 
     /**

--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -2,6 +2,7 @@
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Exception\Exception;
 use Coduo\PHPMatcher\Parser;
 use Coduo\ToString\StringConverter;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -179,9 +180,13 @@ final class ArrayMatcher extends Matcher
         $notExistingKeys = array_diff_key($pattern, $values);
 
         return array_filter($notExistingKeys, function ($pattern) use ($values) {
+            if (is_array($pattern)) {
+                return !$this->match($values, $pattern);
+            }
+
             try {
                 $typePattern = $this->parser->parse($pattern);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 return true;
             }
 

--- a/src/Matcher/Pattern/Expander/Contains.php
+++ b/src/Matcher/Pattern/Expander/Contains.php
@@ -62,4 +62,12 @@ final class Contains implements PatternExpander
     {
         return $this->error;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'contains';
+    }
 }

--- a/src/Matcher/Pattern/Expander/Contains.php
+++ b/src/Matcher/Pattern/Expander/Contains.php
@@ -25,6 +25,14 @@ final class Contains implements PatternExpander
     private $ignoreCase;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param $string
      * @param bool $ignoreCase
      */

--- a/src/Matcher/Pattern/Expander/Contains.php
+++ b/src/Matcher/Pattern/Expander/Contains.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class Contains implements PatternExpander
 {
+    const NAME = 'contains';
+
     /**
      * @var null|string
      */
@@ -61,13 +63,5 @@ final class Contains implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'contains';
     }
 }

--- a/src/Matcher/Pattern/Expander/Count.php
+++ b/src/Matcher/Pattern/Expander/Count.php
@@ -20,6 +20,14 @@ final class Count implements PatternExpander
     private $value;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param $value
      */
     public function __construct($value)

--- a/src/Matcher/Pattern/Expander/Count.php
+++ b/src/Matcher/Pattern/Expander/Count.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class Count implements PatternExpander
 {
+    const NAME = 'count';
+
     /**
      * @var null|string
      */
@@ -50,13 +52,5 @@ final class Count implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'count';
     }
 }

--- a/src/Matcher/Pattern/Expander/Count.php
+++ b/src/Matcher/Pattern/Expander/Count.php
@@ -51,4 +51,12 @@ final class Count implements PatternExpander
     {
         return $this->error;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'count';
+    }
 }

--- a/src/Matcher/Pattern/Expander/EndsWith.php
+++ b/src/Matcher/Pattern/Expander/EndsWith.php
@@ -25,6 +25,14 @@ final class EndsWith implements PatternExpander
     private $ignoreCase;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param string $stringEnding
      * @param bool $ignoreCase
      */

--- a/src/Matcher/Pattern/Expander/EndsWith.php
+++ b/src/Matcher/Pattern/Expander/EndsWith.php
@@ -77,4 +77,12 @@ final class EndsWith implements PatternExpander
             ? mb_substr(mb_strtolower($value), -mb_strlen(mb_strtolower($this->stringEnding))) === mb_strtolower($this->stringEnding)
             : mb_substr($value, -mb_strlen($this->stringEnding)) === $this->stringEnding;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'endsWith';
+    }
 }

--- a/src/Matcher/Pattern/Expander/EndsWith.php
+++ b/src/Matcher/Pattern/Expander/EndsWith.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class EndsWith implements PatternExpander
 {
+    const NAME = 'endsWith';
+
     /**
      * @var
      */
@@ -76,13 +78,5 @@ final class EndsWith implements PatternExpander
         return $this->ignoreCase
             ? mb_substr(mb_strtolower($value), -mb_strlen(mb_strtolower($this->stringEnding))) === mb_strtolower($this->stringEnding)
             : mb_substr($value, -mb_strlen($this->stringEnding)) === $this->stringEnding;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'endsWith';
     }
 }

--- a/src/Matcher/Pattern/Expander/GreaterThan.php
+++ b/src/Matcher/Pattern/Expander/GreaterThan.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class GreaterThan implements PatternExpander
 {
+    const NAME = 'greaterThan';
+
     /**
      * @var
      */
@@ -54,13 +56,5 @@ final class GreaterThan implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'greaterThan';
     }
 }

--- a/src/Matcher/Pattern/Expander/GreaterThan.php
+++ b/src/Matcher/Pattern/Expander/GreaterThan.php
@@ -20,6 +20,14 @@ final class GreaterThan implements PatternExpander
     private $error;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param $boundary
      */
     public function __construct($boundary)

--- a/src/Matcher/Pattern/Expander/GreaterThan.php
+++ b/src/Matcher/Pattern/Expander/GreaterThan.php
@@ -55,4 +55,12 @@ final class GreaterThan implements PatternExpander
     {
         return $this->error;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'greaterThan';
+    }
 }

--- a/src/Matcher/Pattern/Expander/InArray.php
+++ b/src/Matcher/Pattern/Expander/InArray.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class InArray implements PatternExpander
 {
+    const NAME = 'inArray';
+
     /**
      * @var null|string
      */
@@ -50,13 +52,5 @@ final class InArray implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'inArray';
     }
 }

--- a/src/Matcher/Pattern/Expander/InArray.php
+++ b/src/Matcher/Pattern/Expander/InArray.php
@@ -51,4 +51,12 @@ final class InArray implements PatternExpander
     {
         return $this->error;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'inArray';
+    }
 }

--- a/src/Matcher/Pattern/Expander/InArray.php
+++ b/src/Matcher/Pattern/Expander/InArray.php
@@ -20,6 +20,14 @@ final class InArray implements PatternExpander
     private $value;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param $value
      */
     public function __construct($value)

--- a/src/Matcher/Pattern/Expander/IsDateTime.php
+++ b/src/Matcher/Pattern/Expander/IsDateTime.php
@@ -15,6 +15,14 @@ final class IsDateTime implements PatternExpander
     private $error;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param string $value
      * @return boolean
      */

--- a/src/Matcher/Pattern/Expander/IsDateTime.php
+++ b/src/Matcher/Pattern/Expander/IsDateTime.php
@@ -52,4 +52,12 @@ final class IsDateTime implements PatternExpander
             return false;
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'isDateTime';
+    }
 }

--- a/src/Matcher/Pattern/Expander/IsDateTime.php
+++ b/src/Matcher/Pattern/Expander/IsDateTime.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class IsDateTime implements PatternExpander
 {
+    const NAME = 'isDateTime';
+
     /**
      * @var null|string
      */
@@ -51,13 +53,5 @@ final class IsDateTime implements PatternExpander
         } catch (\Exception $e) {
             return false;
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'isDateTime';
     }
 }

--- a/src/Matcher/Pattern/Expander/IsEmail.php
+++ b/src/Matcher/Pattern/Expander/IsEmail.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class IsEmail implements PatternExpander
 {
+    const NAME = 'isEmail';
+
     /**
      * @var null|string
      */
@@ -50,13 +52,5 @@ final class IsEmail implements PatternExpander
         } catch (\Exception $e) {
             return false;
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'isEmail';
     }
 }

--- a/src/Matcher/Pattern/Expander/IsEmail.php
+++ b/src/Matcher/Pattern/Expander/IsEmail.php
@@ -51,4 +51,12 @@ final class IsEmail implements PatternExpander
             return false;
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'isEmail';
+    }
 }

--- a/src/Matcher/Pattern/Expander/IsEmail.php
+++ b/src/Matcher/Pattern/Expander/IsEmail.php
@@ -15,6 +15,14 @@ final class IsEmail implements PatternExpander
     private $error;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param string $value
      * @return boolean
      */

--- a/src/Matcher/Pattern/Expander/IsEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsEmpty.php
@@ -32,4 +32,12 @@ final class IsEmpty implements PatternExpander
     {
         return $this->error;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'isEmpty';
+    }
 }

--- a/src/Matcher/Pattern/Expander/IsEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsEmpty.php
@@ -12,6 +12,14 @@ final class IsEmpty implements PatternExpander
     private $error;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param mixed $value
      *
      * @return boolean

--- a/src/Matcher/Pattern/Expander/IsEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsEmpty.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class IsEmpty implements PatternExpander
 {
+    const NAME = 'isEmpty';
+
     private $error;
 
     /**
@@ -31,13 +33,5 @@ final class IsEmpty implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'isEmpty';
     }
 }

--- a/src/Matcher/Pattern/Expander/IsNotEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsNotEmpty.php
@@ -12,6 +12,14 @@ final class IsNotEmpty implements PatternExpander
     private $error;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param $value
      * @return boolean
      */

--- a/src/Matcher/Pattern/Expander/IsNotEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsNotEmpty.php
@@ -30,4 +30,12 @@ final class IsNotEmpty implements PatternExpander
     {
         return $this->error;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'isNotEmpty';
+    }
 }

--- a/src/Matcher/Pattern/Expander/IsNotEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsNotEmpty.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class IsNotEmpty implements PatternExpander
 {
+    const NAME = 'isNotEmpty';
+
     private $error;
 
     /**
@@ -29,13 +31,5 @@ final class IsNotEmpty implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'isNotEmpty';
     }
 }

--- a/src/Matcher/Pattern/Expander/IsUrl.php
+++ b/src/Matcher/Pattern/Expander/IsUrl.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class IsUrl implements PatternExpander
 {
+    const NAME = 'isUrl';
+
     /**
      * @var null|string
      */
@@ -50,13 +52,5 @@ final class IsUrl implements PatternExpander
         } catch (\Exception $e) {
             return false;
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'isUrl';
     }
 }

--- a/src/Matcher/Pattern/Expander/IsUrl.php
+++ b/src/Matcher/Pattern/Expander/IsUrl.php
@@ -51,4 +51,12 @@ final class IsUrl implements PatternExpander
             return false;
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'isUrl';
+    }
 }

--- a/src/Matcher/Pattern/Expander/IsUrl.php
+++ b/src/Matcher/Pattern/Expander/IsUrl.php
@@ -15,6 +15,14 @@ final class IsUrl implements PatternExpander
     private $error;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param string $value
      * @return boolean
      */

--- a/src/Matcher/Pattern/Expander/LowerThan.php
+++ b/src/Matcher/Pattern/Expander/LowerThan.php
@@ -55,4 +55,12 @@ final class LowerThan implements PatternExpander
     {
         return $this->error;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'lowerThan';
+    }
 }

--- a/src/Matcher/Pattern/Expander/LowerThan.php
+++ b/src/Matcher/Pattern/Expander/LowerThan.php
@@ -20,6 +20,14 @@ final class LowerThan implements PatternExpander
     private $error;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param $boundary
      */
     public function __construct($boundary)

--- a/src/Matcher/Pattern/Expander/LowerThan.php
+++ b/src/Matcher/Pattern/Expander/LowerThan.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class LowerThan implements PatternExpander
 {
+    const NAME = 'lowerThan';
+
     /**
      * @var
      */
@@ -54,13 +56,5 @@ final class LowerThan implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'lowerThan';
     }
 }

--- a/src/Matcher/Pattern/Expander/MatchRegex.php
+++ b/src/Matcher/Pattern/Expander/MatchRegex.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class MatchRegex implements PatternExpander
 {
+    const NAME = 'matchRegex';
+
     /**
      * @var null|string
      */
@@ -61,13 +63,5 @@ final class MatchRegex implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'matchRegex';
     }
 }

--- a/src/Matcher/Pattern/Expander/MatchRegex.php
+++ b/src/Matcher/Pattern/Expander/MatchRegex.php
@@ -20,6 +20,14 @@ final class MatchRegex implements PatternExpander
     private $pattern;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param string $pattern
      */
     public function __construct($pattern)

--- a/src/Matcher/Pattern/Expander/MatchRegex.php
+++ b/src/Matcher/Pattern/Expander/MatchRegex.php
@@ -62,4 +62,12 @@ final class MatchRegex implements PatternExpander
     {
         return $this->error;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'matchRegex';
+    }
 }

--- a/src/Matcher/Pattern/Expander/OneOf.php
+++ b/src/Matcher/Pattern/Expander/OneOf.php
@@ -51,4 +51,12 @@ final class OneOf implements PatternExpander
     {
         return $this->error;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'oneOf';
+    }
 }

--- a/src/Matcher/Pattern/Expander/OneOf.php
+++ b/src/Matcher/Pattern/Expander/OneOf.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class OneOf implements PatternExpander
 {
+    const NAME = 'oneOf';
+
     /**
      * @var PatternExpander[]
      */
@@ -50,13 +52,5 @@ final class OneOf implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'oneOf';
     }
 }

--- a/src/Matcher/Pattern/Expander/OneOf.php
+++ b/src/Matcher/Pattern/Expander/OneOf.php
@@ -16,6 +16,14 @@ final class OneOf implements PatternExpander
 
     protected $error;
 
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
     public function __construct()
     {
         if (func_num_args() < 2) {

--- a/src/Matcher/Pattern/Expander/Optional.php
+++ b/src/Matcher/Pattern/Expander/Optional.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+
+final class Optional implements PatternExpander
+{
+    /**
+     * @param mixed $value
+     *
+     * @return boolean
+     */
+    public function match($value)
+    {
+        return true;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getError()
+    {
+        return null;
+    }
+}

--- a/src/Matcher/Pattern/Expander/Optional.php
+++ b/src/Matcher/Pattern/Expander/Optional.php
@@ -7,9 +7,7 @@ use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
 final class Optional implements PatternExpander
 {
     /**
-     * @param mixed $value
-     *
-     * @return boolean
+     * {@inheritdoc}
      */
     public function match($value)
     {
@@ -17,10 +15,18 @@ final class Optional implements PatternExpander
     }
 
     /**
-     * @return string|null
+     * {@inheritdoc}
      */
     public function getError()
     {
         return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'optional';
     }
 }

--- a/src/Matcher/Pattern/Expander/Optional.php
+++ b/src/Matcher/Pattern/Expander/Optional.php
@@ -11,6 +11,14 @@ final class Optional implements PatternExpander
     /**
      * {@inheritdoc}
      */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function match($value)
     {
         return true;

--- a/src/Matcher/Pattern/Expander/Optional.php
+++ b/src/Matcher/Pattern/Expander/Optional.php
@@ -6,6 +6,8 @@ use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
 
 final class Optional implements PatternExpander
 {
+    const NAME = 'optional';
+
     /**
      * {@inheritdoc}
      */
@@ -20,13 +22,5 @@ final class Optional implements PatternExpander
     public function getError()
     {
         return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'optional';
     }
 }

--- a/src/Matcher/Pattern/Expander/StartsWith.php
+++ b/src/Matcher/Pattern/Expander/StartsWith.php
@@ -25,6 +25,14 @@ final class StartsWith implements PatternExpander
     private $ignoreCase;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
      * @param string $stringBeginning
      * @param bool $ignoreCase
      */

--- a/src/Matcher/Pattern/Expander/StartsWith.php
+++ b/src/Matcher/Pattern/Expander/StartsWith.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class StartsWith implements PatternExpander
 {
+    const NAME = 'startsWith';
+
     /**
      * @var
      */
@@ -65,14 +67,6 @@ final class StartsWith implements PatternExpander
     public function getError()
     {
         return $this->error;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'startsWith';
     }
 
     /**

--- a/src/Matcher/Pattern/Expander/StartsWith.php
+++ b/src/Matcher/Pattern/Expander/StartsWith.php
@@ -68,6 +68,14 @@ final class StartsWith implements PatternExpander
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'startsWith';
+    }
+
+    /**
      * @param $value
      * @return bool
      */

--- a/src/Matcher/Pattern/Pattern.php
+++ b/src/Matcher/Pattern/Pattern.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher\Pattern;
 
@@ -13,12 +13,21 @@ interface Pattern
      * @param $value
      * @return boolean
      */
-    public function matchExpanders($value);
+    public function matchExpanders($value): bool;
 
     /**
      * Return error message from first expander that doesn't match.
      *
      * @return null|string
      */
-    public function getError();
+    public function getError(): ?string;
+
+    /**
+     * Checks whether a Pattern has added Expander.
+     *
+     * @param string $expanderName The name of the expander
+     *
+     * @return bool true if the specified pattern has expander, false otherwise
+     */
+    public function hasExpander(string $expanderName): bool;
 }

--- a/src/Matcher/Pattern/Pattern.php
+++ b/src/Matcher/Pattern/Pattern.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Coduo\PHPMatcher\Matcher\Pattern;
 
@@ -13,14 +13,14 @@ interface Pattern
      * @param $value
      * @return boolean
      */
-    public function matchExpanders($value): bool;
+    public function matchExpanders($value);
 
     /**
      * Return error message from first expander that doesn't match.
      *
      * @return null|string
      */
-    public function getError(): ?string;
+    public function getError();
 
     /**
      * Checks whether a Pattern has added Expander.
@@ -29,5 +29,5 @@ interface Pattern
      *
      * @return bool true if the specified pattern has expander, false otherwise
      */
-    public function hasExpander(string $expanderName): bool;
+    public function hasExpander(string $expanderName);
 }

--- a/src/Matcher/Pattern/PatternExpander.php
+++ b/src/Matcher/Pattern/PatternExpander.php
@@ -14,4 +14,11 @@ interface PatternExpander
      * @return string|null
      */
     public function getError();
+
+    /**
+     * Returns the name by which the expander is identified.
+     *
+     * @return string The name of the expander
+     */
+    public function getName();
 }

--- a/src/Matcher/Pattern/PatternExpander.php
+++ b/src/Matcher/Pattern/PatternExpander.php
@@ -14,11 +14,4 @@ interface PatternExpander
      * @return string|null
      */
     public function getError();
-
-    /**
-     * Returns the name by which the expander is identified.
-     *
-     * @return string The name of the expander
-     */
-    public function getName();
 }

--- a/src/Matcher/Pattern/PatternExpander.php
+++ b/src/Matcher/Pattern/PatternExpander.php
@@ -5,6 +5,12 @@ namespace Coduo\PHPMatcher\Matcher\Pattern;
 interface PatternExpander
 {
     /**
+     * @param string $name
+     * @return bool
+     */
+    public static function is(string $name);
+
+    /**
      * @param $value
      * @return boolean
      */

--- a/src/Matcher/Pattern/TypePattern.php
+++ b/src/Matcher/Pattern/TypePattern.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Coduo\PHPMatcher\Matcher\Pattern;
 
@@ -41,7 +41,7 @@ final class TypePattern implements Pattern
      * @param $type
      * @return boolean
      */
-    public function is($type): bool
+    public function is($type)
     {
         return strtolower($this->type) === strtolower($type);
     }
@@ -49,7 +49,7 @@ final class TypePattern implements Pattern
     /**
      * @return string
      */
-    public function getType(): ?string
+    public function getType()
     {
         return strtolower($this->type);
     }
@@ -65,7 +65,7 @@ final class TypePattern implements Pattern
     /**
      * {@inheritdoc}
      */
-    public function matchExpanders($value): bool
+    public function matchExpanders($value)
     {
         foreach ($this->expanders as $expander) {
             if (!$expander->match($value)) {
@@ -80,7 +80,7 @@ final class TypePattern implements Pattern
     /**
      * {@inheritdoc}
      */
-    public function getError(): ?string
+    public function getError()
     {
         return $this->error;
     }
@@ -88,7 +88,7 @@ final class TypePattern implements Pattern
     /**
      * {@inheritdoc}
      */
-    public function hasExpander(string $expanderName): bool
+    public function hasExpander(string $expanderName)
     {
         foreach ($this->expanders as $expander) {
             if (!$this->expanderInitializer->hasExpanderDefinition($expanderName)) {

--- a/src/Matcher/Pattern/TypePattern.php
+++ b/src/Matcher/Pattern/TypePattern.php
@@ -82,7 +82,7 @@ final class TypePattern implements Pattern
     public function hasExpander(string $expanderName)
     {
         foreach ($this->expanders as $expander) {
-            if ($expander::NAME === $expanderName) {
+            if ($expander::is($expanderName)) {
                 return true;
             }
         }

--- a/src/Matcher/Pattern/TypePattern.php
+++ b/src/Matcher/Pattern/TypePattern.php
@@ -1,6 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher\Pattern;
+
+use Coduo\PHPMatcher\Parser\ExpanderInitializer;
 
 final class TypePattern implements Pattern
 {
@@ -20,19 +22,26 @@ final class TypePattern implements Pattern
     private $error;
 
     /**
-     * @param string $type
+     * @var ExpanderInitializer
      */
-    public function __construct($type)
+    private $expanderInitializer;
+
+    /**
+     * @param string $type
+     * @param ExpanderInitializer $expanderInitializer
+     */
+    public function __construct($type, ExpanderInitializer $expanderInitializer)
     {
         $this->type = $type;
         $this->expanders = array();
+        $this->expanderInitializer = $expanderInitializer;
     }
 
     /**
      * @param $type
      * @return boolean
      */
-    public function is($type)
+    public function is($type): bool
     {
         return strtolower($this->type) === strtolower($type);
     }
@@ -40,7 +49,7 @@ final class TypePattern implements Pattern
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): ?string
     {
         return strtolower($this->type);
     }
@@ -56,7 +65,7 @@ final class TypePattern implements Pattern
     /**
      * {@inheritdoc}
      */
-    public function matchExpanders($value)
+    public function matchExpanders($value): bool
     {
         foreach ($this->expanders as $expander) {
             if (!$expander->match($value)) {
@@ -69,10 +78,28 @@ final class TypePattern implements Pattern
     }
 
     /**
-     * @return null|string
+     * {@inheritdoc}
      */
-    public function getError()
+    public function getError(): ?string
     {
         return $this->error;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasExpander(string $expanderName): bool
+    {
+        foreach ($this->expanders as $expander) {
+            if (!$this->expanderInitializer->hasExpanderDefinition($expanderName)) {
+                continue;
+            }
+
+            if ($this->expanderInitializer->getExpanderDefinition($expanderName) === get_class($expander)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Matcher/Pattern/TypePattern.php
+++ b/src/Matcher/Pattern/TypePattern.php
@@ -2,8 +2,6 @@
 
 namespace Coduo\PHPMatcher\Matcher\Pattern;
 
-use Coduo\PHPMatcher\Parser\ExpanderInitializer;
-
 final class TypePattern implements Pattern
 {
     /**
@@ -22,19 +20,12 @@ final class TypePattern implements Pattern
     private $error;
 
     /**
-     * @var ExpanderInitializer
-     */
-    private $expanderInitializer;
-
-    /**
      * @param string $type
-     * @param ExpanderInitializer $expanderInitializer
      */
-    public function __construct($type, ExpanderInitializer $expanderInitializer)
+    public function __construct($type)
     {
         $this->type = $type;
         $this->expanders = array();
-        $this->expanderInitializer = $expanderInitializer;
     }
 
     /**
@@ -91,11 +82,7 @@ final class TypePattern implements Pattern
     public function hasExpander(string $expanderName)
     {
         foreach ($this->expanders as $expander) {
-            if (!$this->expanderInitializer->hasExpanderDefinition($expanderName)) {
-                continue;
-            }
-
-            if ($this->expanderInitializer->getExpanderDefinition($expanderName) === get_class($expander)) {
+            if ($expander->getName() === $expanderName) {
                 return true;
             }
         }

--- a/src/Matcher/Pattern/TypePattern.php
+++ b/src/Matcher/Pattern/TypePattern.php
@@ -82,7 +82,7 @@ final class TypePattern implements Pattern
     public function hasExpander(string $expanderName)
     {
         foreach ($this->expanders as $expander) {
-            if ($expander->getName() === $expanderName) {
+            if ($expander::NAME === $expanderName) {
                 return true;
             }
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -54,7 +54,7 @@ final class Parser
     public function parse($pattern)
     {
         $AST = $this->getAST($pattern);
-        $pattern = new Pattern\TypePattern((string) $AST->getType());
+        $pattern = new Pattern\TypePattern((string) $AST->getType(), $this->expanderInitializer);
         foreach ($AST->getExpanders() as $expander) {
             $pattern->addExpander($this->expanderInitializer->initialize($expander));
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -54,7 +54,7 @@ final class Parser
     public function parse($pattern)
     {
         $AST = $this->getAST($pattern);
-        $pattern = new Pattern\TypePattern((string) $AST->getType(), $this->expanderInitializer);
+        $pattern = new Pattern\TypePattern((string) $AST->getType());
         foreach ($AST->getExpanders() as $expander) {
             $pattern->addExpander($this->expanderInitializer->initialize($expander));
         }

--- a/src/Parser/ExpanderInitializer.php
+++ b/src/Parser/ExpanderInitializer.php
@@ -28,7 +28,7 @@ final class ExpanderInitializer
         "count" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\Count",
         "contains" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\Contains",
         "matchRegex" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\MatchRegex",
-
+        "optional" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\Optional",
         "oneOf" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\OneOf"
     );
 

--- a/src/Parser/ExpanderInitializer.php
+++ b/src/Parser/ExpanderInitializer.php
@@ -2,35 +2,36 @@
 
 namespace Coduo\PHPMatcher\Parser;
 
-use Coduo\PHPMatcher\AST\Expander;
+use Coduo\PHPMatcher\AST\Expander as ExpanderNode;
 use Coduo\PHPMatcher\Exception\InvalidArgumentException;
 use Coduo\PHPMatcher\Exception\InvalidExpanderTypeException;
 use Coduo\PHPMatcher\Exception\UnknownExpanderClassException;
 use Coduo\PHPMatcher\Exception\UnknownExpanderException;
 use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander;
 
 final class ExpanderInitializer
 {
     /**
      * @var array
      */
-    private $expanderDefinitions = array(
-        "startsWith" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\StartsWith",
-        "endsWith" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\EndsWith",
-        "isNotEmpty" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsNotEmpty",
-        "isEmpty" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsEmpty",
-        "isDateTime" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsDateTime",
-        "isEmail" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsEmail",
-        "isUrl" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsUrl",
-        "lowerThan" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\LowerThan",
-        "greaterThan" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\GreaterThan",
-        "inArray" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\InArray",
-        "count" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\Count",
-        "contains" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\Contains",
-        "matchRegex" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\MatchRegex",
-        "optional" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\Optional",
-        "oneOf" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\OneOf"
-    );
+    private $expanderDefinitions = [
+        Expander\Contains::NAME => Expander\Contains::class,
+        Expander\Count::NAME => Expander\Count::class,
+        Expander\EndsWith::NAME => Expander\EndsWith::class,
+        Expander\GreaterThan::NAME => Expander\GreaterThan::class,
+        Expander\InArray::NAME => Expander\InArray::class,
+        Expander\IsDateTime::NAME => Expander\IsDateTime::class,
+        Expander\IsEmail::NAME => Expander\IsEmail::class,
+        Expander\IsEmpty::NAME => Expander\IsEmpty::class,
+        Expander\IsNotEmpty::NAME => Expander\IsNotEmpty::class,
+        Expander\IsUrl::NAME => Expander\IsUrl::class,
+        Expander\LowerThan::NAME => Expander\LowerThan::class,
+        Expander\MatchRegex::NAME => Expander\MatchRegex::class,
+        Expander\OneOf::NAME => Expander\OneOf::class,
+        Expander\Optional::NAME => Expander\Optional::class,
+        Expander\StartsWith::NAME => Expander\StartsWith::class,
+    ];
 
     /**
      * @param string $expanderName
@@ -70,12 +71,12 @@ final class ExpanderInitializer
     }
 
     /**
-     * @param Expander $expanderNode
+     * @param ExpanderNode $expanderNode
      * @throws InvalidExpanderTypeException
      * @throws UnknownExpanderException
      * @return PatternExpander
      */
-    public function initialize(Expander $expanderNode)
+    public function initialize(ExpanderNode $expanderNode)
     {
         if (!array_key_exists($expanderNode->getName(), $this->expanderDefinitions)) {
             throw new UnknownExpanderException(sprintf("Unknown expander \"%s\"", $expanderNode->getName()));
@@ -86,7 +87,7 @@ final class ExpanderInitializer
         if ($expanderNode->hasArguments()) {
             $arguments = array();
             foreach ($expanderNode->getArguments() as $argument) {
-                $arguments[] = ($argument instanceof Expander)
+                $arguments[] = ($argument instanceof ExpanderNode)
                     ? $this->initialize($argument)
                     : $argument;
             }

--- a/tests/Matcher/Pattern/Expander/OptionalTest.php
+++ b/tests/Matcher/Pattern/Expander/OptionalTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\Optional;
+
+class OptionalTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_optional_expander_match($value, $expectedResult)
+    {
+        $expander = new Optional();
+        $this->assertEquals($expectedResult, $expander->match($value));
+    }
+
+    public static function examplesProvider()
+    {
+        return array(
+            array(array(), true),
+            array(array('data'), true),
+            array('', true),
+            array(0, true),
+            array(10.1, true),
+            array(null, true),
+            array('Lorem ipsum', true),
+        );
+    }
+}

--- a/tests/Matcher/Pattern/PatternTest.php
+++ b/tests/Matcher/Pattern/PatternTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern;
+
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\IsEmail;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\IsEmpty;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\Optional;
+use Coduo\PHPMatcher\Matcher\Pattern\Pattern;
+use Coduo\PHPMatcher\Matcher\Pattern\TypePattern;
+use Coduo\PHPMatcher\Parser\ExpanderInitializer;
+
+class PatternTest  extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Pattern
+     */
+    private $pattern;
+
+    public function setUp()
+    {
+        $this->pattern = new TypePattern('dummy', new ExpanderInitializer());
+        $this->pattern->addExpander(new isEmail());
+        $this->pattern->addExpander(new isEmpty());
+        $this->pattern->addExpander(new Optional());
+    }
+
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_has_expander($expander, $expectedResult)
+    {
+        $this->assertEquals($expectedResult, $this->pattern->hasExpander($expander));
+    }
+
+    public static function examplesProvider()
+    {
+        return array(
+            array("isEmail", true),
+            array("isEmpty", true),
+            array("optional", true),
+            array("isUrl", false),
+            array("non existing expander", false),
+        );
+    }
+}

--- a/tests/Matcher/Pattern/PatternTest.php
+++ b/tests/Matcher/Pattern/PatternTest.php
@@ -7,7 +7,6 @@ use Coduo\PHPMatcher\Matcher\Pattern\Expander\IsEmpty;
 use Coduo\PHPMatcher\Matcher\Pattern\Expander\Optional;
 use Coduo\PHPMatcher\Matcher\Pattern\Pattern;
 use Coduo\PHPMatcher\Matcher\Pattern\TypePattern;
-use Coduo\PHPMatcher\Parser\ExpanderInitializer;
 
 class PatternTest  extends \PHPUnit\Framework\TestCase
 {
@@ -18,7 +17,7 @@ class PatternTest  extends \PHPUnit\Framework\TestCase
 
     public function setUp()
     {
-        $this->pattern = new TypePattern('dummy', new ExpanderInitializer());
+        $this->pattern = new TypePattern('dummy');
         $this->pattern->addExpander(new isEmail());
         $this->pattern->addExpander(new isEmpty());
         $this->pattern->addExpander(new Optional());

--- a/tests/Matcher/Pattern/RegexConverterTest.php
+++ b/tests/Matcher/Pattern/RegexConverterTest.php
@@ -4,6 +4,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher\Pattern;
 
 use Coduo\PHPMatcher\Matcher\Pattern\TypePattern;
 use Coduo\PHPMatcher\Matcher\Pattern\RegexConverter;
+use Coduo\PHPMatcher\Parser\ExpanderInitializer;
 
 class RegexConverterTest  extends \PHPUnit\Framework\TestCase
 {
@@ -22,6 +23,6 @@ class RegexConverterTest  extends \PHPUnit\Framework\TestCase
      */
     public function test_convert_unknown_type()
     {
-        $this->converter->toRegex(new TypePattern("not_a_type"));
+        $this->converter->toRegex(new TypePattern("not_a_type", new ExpanderInitializer()));
     }
 }

--- a/tests/Matcher/Pattern/RegexConverterTest.php
+++ b/tests/Matcher/Pattern/RegexConverterTest.php
@@ -4,7 +4,6 @@ namespace Coduo\PHPMatcher\Tests\Matcher\Pattern;
 
 use Coduo\PHPMatcher\Matcher\Pattern\TypePattern;
 use Coduo\PHPMatcher\Matcher\Pattern\RegexConverter;
-use Coduo\PHPMatcher\Parser\ExpanderInitializer;
 
 class RegexConverterTest  extends \PHPUnit\Framework\TestCase
 {
@@ -23,6 +22,6 @@ class RegexConverterTest  extends \PHPUnit\Framework\TestCase
      */
     public function test_convert_unknown_type()
     {
-        $this->converter->toRegex(new TypePattern("not_a_type", new ExpanderInitializer()));
+        $this->converter->toRegex(new TypePattern("not_a_type"));
     }
 }

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -261,7 +261,7 @@ XML;
   <m:GetStockPrice>
     <m:StockName>@string@.optional()</m:StockName>
     <m:StockValue>@string@.optional()</m:StockValue>
-    <m:StockQty>@string@.optional()</m:StockQty>
+    <m:StockQty>@integer@.optional()</m:StockQty>
   </m:GetStockPrice>
 </soap:Body>
 

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -175,6 +175,23 @@ class MatcherTest extends \PHPUnit\Framework\TestCase
                     "nextPage": "@string@"
                 }',
             ),
+            'excludes missing property from match for optional property' => array(
+                /** @lang JSON */
+                '{
+                    "users":[],
+                    "prevPage": "http:\/\/example.com\/api\/users\/1?limit=2",
+                    "currPage": 2
+                }',
+                /** @lang JSON */
+                '{
+                    "users":[
+                        "@...@"                        
+                    ],
+                    "prevPage": "@string@.optional()",
+                    "nextPage": "@string@.optional()",
+                    "currPage": "@integer@.optional()"
+                }',
+            ),
         );
     }
 
@@ -205,6 +222,46 @@ XML;
   <m:GetStockPrice>
     <m:StockName>@string@</m:StockName>
     <m:StockValue>@string@</m:StockValue>
+  </m:GetStockPrice>
+</soap:Body>
+
+</soap:Envelope>
+XML;
+
+        $this->assertTrue($this->matcher->match($xml, $xmlPattern));
+        $this->assertTrue(PHPMatcher::match($xml, $xmlPattern));
+    }
+
+
+
+    public function test_matcher_with_xml_including_optional_node()
+    {
+        $xml = <<<XML
+<?xml version="1.0"?>
+<soap:Envelope
+xmlns:soap="http://www.w3.org/2001/12/soap-envelope"
+soap:encodingStyle="http://www.w3.org/2001/12/soap-encoding">
+
+<soap:Body xmlns:m="http://www.example.org/stock">
+  <m:GetStockPrice>
+    <m:StockName>IBM</m:StockName>
+    <m:StockValue>Any Value</m:StockValue>
+  </m:GetStockPrice>
+</soap:Body>
+
+</soap:Envelope>
+XML;
+        $xmlPattern = <<<XML
+<?xml version="1.0"?>
+<soap:Envelope
+    xmlns:soap="@string@"
+            soap:encodingStyle="@string@">
+
+<soap:Body xmlns:m="@string@">
+  <m:GetStockPrice>
+    <m:StockName>@string@.optional()</m:StockName>
+    <m:StockValue>@string@.optional()</m:StockValue>
+    <m:StockQty>@string@.optional()</m:StockQty>
   </m:GetStockPrice>
 </soap:Body>
 


### PR DESCRIPTION
# What has been done

 - [x] added `optional` expander 
>useless for scalar matchers
 - [x] allows to mark JSON properties & XML nodes as optional
> should resolve #93 
> `optional()` expander is also available for `ArrayMatcher` due to `JsonMatcher` & `XmlMatcher` is created using `ArrayMatcher`. There's no a simple way to exclude `optional()` expander functionality from `ArrayMatcher` 
 - [x] added test cases for `MatcherTest`
 - [x] **Matcher/Pattern/Pattern** now have new method `hasExpander(string $expanderName): bool`

-----

##  ~~Other's~~

 ~~Also return type declaration was added for for *Pattern inteface*.~~