### PR TITLE
Allow to mark JSON properties & XML nodes as optional (#102)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,8 @@ cache:
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.6
       env: DEPENDENCIES='low'
-    - php: 5.3
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ $matcher->getError(); // returns null or error message
 * ``inArray($value)``
 * ``oneOf(...$expanders)`` - example usage ``"@string@.oneOf(contains('foo'), contains('bar'), contains('baz'))"``
 * ``matchRegex($regex)`` - example usage ``"@string@.matchRegex('/^lorem.+/')"``
+* ``optional()`` - work's only with ``ArrayMatcher``, ``JsonMatcher`` and ``XmlMatcher``
 
 ##Example usage
 
@@ -237,7 +238,8 @@ $matcher->match(
               'id' => 1,
               'firstName' => 'Norbert',
               'lastName' => 'Orzechowicz',
-              'roles' => array('ROLE_USER')
+              'roles' => array('ROLE_USER'),
+              'position' => 'Developer',
           ),
           array(
               'id' => 2,
@@ -261,7 +263,8 @@ $matcher->match(
               'id' => '@integer@.greaterThan(0)',
               'firstName' => '@string@',
               'lastName' => 'Orzechowicz',
-              'roles' => '@array@'
+              'roles' => '@array@',
+              'position' => '@string@.optional()'
           ),
           array(
               'id' => '@integer@',
@@ -303,7 +306,8 @@ $matcher->match(
         "firstName": @string@,
         "lastName": @string@,
         "created": "@string@.isDateTime()",
-        "roles": @array@
+        "roles": @array@,
+        "posiiton": "@string@.optional()"
       }
     ]
   }'
@@ -347,6 +351,7 @@ XML
   <m:GetStockPrice>
     <m:StockName>@string@</m:StockName>
     <m:StockValue>@string@</m:StockValue>
+    <m:StockQty>@integer@.optional()</m:StockQty>
   </m:GetStockPrice>
 </soap:Body>
 

--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -2,6 +2,7 @@
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Exception\Exception;
 use Coduo\PHPMatcher\Parser;
 use Coduo\ToString\StringConverter;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -144,17 +145,54 @@ final class ArrayMatcher extends Matcher
     private function isPatternValid(array $pattern, array $values, $parentPath)
     {
         if (is_array($pattern)) {
-            $notExistingKeys = array_diff_key($pattern, $values);
+            $skipPattern = static::UNBOUNDED_PATTERN;
+
+            $pattern = array_filter(
+                $pattern,
+                function ($item) use ($skipPattern) {
+                    return $item !== $skipPattern;
+                }
+            );
+
+            $notExistingKeys = $this->findNotExistingKeys($pattern, $values);
 
             if (count($notExistingKeys) > 0) {
                 $keyNames = array_keys($notExistingKeys);
                 $path = $this->formatFullPath($parentPath, $this->formatAccessPath($keyNames[0]));
                 $this->setMissingElementInError('value', $path);
+
                 return false;
             }
         }
 
         return true;
+    }
+
+    /**
+     * Finds not existing keys
+     * Excludes keys with pattern which includes Optional Expander
+     *
+     * @param $pattern
+     * @param $values
+     * @return array
+     */
+    private function findNotExistingKeys($pattern, $values)
+    {
+        $notExistingKeys = array_diff_key($pattern, $values);
+
+        return array_filter($notExistingKeys, function ($pattern) use ($values) {
+            if (is_array($pattern)) {
+                return !$this->match($values, $pattern);
+            }
+
+            try {
+                $typePattern = $this->parser->parse($pattern);
+            } catch (Exception $e) {
+                return true;
+            }
+
+            return !$typePattern->hasExpander('optional');
+        });
     }
 
     /**

--- a/src/Matcher/Pattern/Expander/Contains.php
+++ b/src/Matcher/Pattern/Expander/Contains.php
@@ -27,7 +27,7 @@ final class Contains implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/Contains.php
+++ b/src/Matcher/Pattern/Expander/Contains.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class Contains implements PatternExpander
 {
+    const NAME = 'contains';
+
     /**
      * @var null|string
      */
@@ -21,6 +23,14 @@ final class Contains implements PatternExpander
      * @var bool
      */
     private $ignoreCase;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param $string

--- a/src/Matcher/Pattern/Expander/Count.php
+++ b/src/Matcher/Pattern/Expander/Count.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class Count implements PatternExpander
 {
+    const NAME = 'count';
+
     /**
      * @var null|string
      */
@@ -16,6 +18,14 @@ final class Count implements PatternExpander
      * @var
      */
     private $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param $value

--- a/src/Matcher/Pattern/Expander/Count.php
+++ b/src/Matcher/Pattern/Expander/Count.php
@@ -22,7 +22,7 @@ final class Count implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/EndsWith.php
+++ b/src/Matcher/Pattern/Expander/EndsWith.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class EndsWith implements PatternExpander
 {
+    const NAME = 'endsWith';
+
     /**
      * @var
      */
@@ -21,6 +23,14 @@ final class EndsWith implements PatternExpander
      * @var bool
      */
     private $ignoreCase;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param string $stringEnding

--- a/src/Matcher/Pattern/Expander/EndsWith.php
+++ b/src/Matcher/Pattern/Expander/EndsWith.php
@@ -27,7 +27,7 @@ final class EndsWith implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }
@@ -41,7 +41,7 @@ final class EndsWith implements PatternExpander
         if (!is_string($stringEnding)) {
             throw new \InvalidArgumentException("String ending must be a valid string.");
         }
-        
+
         $this->stringEnding = $stringEnding;
         $this->ignoreCase = $ignoreCase;
     }

--- a/src/Matcher/Pattern/Expander/GreaterThan.php
+++ b/src/Matcher/Pattern/Expander/GreaterThan.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class GreaterThan implements PatternExpander
 {
+    const NAME = 'greaterThan';
+
     /**
      * @var
      */
@@ -16,6 +18,14 @@ final class GreaterThan implements PatternExpander
      * @var null|string
      */
     private $error;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param $boundary

--- a/src/Matcher/Pattern/Expander/GreaterThan.php
+++ b/src/Matcher/Pattern/Expander/GreaterThan.php
@@ -22,7 +22,7 @@ final class GreaterThan implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/InArray.php
+++ b/src/Matcher/Pattern/Expander/InArray.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class InArray implements PatternExpander
 {
+    const NAME = 'inArray';
+
     /**
      * @var null|string
      */
@@ -16,6 +18,14 @@ final class InArray implements PatternExpander
      * @var
      */
     private $value;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param $value

--- a/src/Matcher/Pattern/Expander/InArray.php
+++ b/src/Matcher/Pattern/Expander/InArray.php
@@ -22,7 +22,7 @@ final class InArray implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/IsDateTime.php
+++ b/src/Matcher/Pattern/Expander/IsDateTime.php
@@ -17,7 +17,7 @@ final class IsDateTime implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/IsDateTime.php
+++ b/src/Matcher/Pattern/Expander/IsDateTime.php
@@ -7,10 +7,20 @@ use Coduo\ToString\StringConverter;
 
 final class IsDateTime implements PatternExpander
 {
+    const NAME = 'isDateTime';
+
     /**
      * @var null|string
      */
     private $error;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param string $value

--- a/src/Matcher/Pattern/Expander/IsEmail.php
+++ b/src/Matcher/Pattern/Expander/IsEmail.php
@@ -17,7 +17,7 @@ final class IsEmail implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/IsEmail.php
+++ b/src/Matcher/Pattern/Expander/IsEmail.php
@@ -7,10 +7,20 @@ use Coduo\ToString\StringConverter;
 
 final class IsEmail implements PatternExpander
 {
+    const NAME = 'isEmail';
+
     /**
      * @var null|string
      */
     private $error;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param string $value

--- a/src/Matcher/Pattern/Expander/IsEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsEmpty.php
@@ -7,7 +7,17 @@ use Coduo\ToString\StringConverter;
 
 final class IsEmpty implements PatternExpander
 {
+    const NAME = 'isEmpty';
+
     private $error;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param mixed $value

--- a/src/Matcher/Pattern/Expander/IsEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsEmpty.php
@@ -14,7 +14,7 @@ final class IsEmpty implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/IsNotEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsNotEmpty.php
@@ -7,7 +7,17 @@ use Coduo\ToString\StringConverter;
 
 final class IsNotEmpty implements PatternExpander
 {
+    const NAME = 'isNotEmpty';
+
     private $error;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param $value

--- a/src/Matcher/Pattern/Expander/IsNotEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsNotEmpty.php
@@ -14,7 +14,7 @@ final class IsNotEmpty implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/IsUrl.php
+++ b/src/Matcher/Pattern/Expander/IsUrl.php
@@ -7,10 +7,20 @@ use Coduo\ToString\StringConverter;
 
 final class IsUrl implements PatternExpander
 {
+    const NAME = 'isUrl';
+
     /**
      * @var null|string
      */
     private $error;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param string $value

--- a/src/Matcher/Pattern/Expander/IsUrl.php
+++ b/src/Matcher/Pattern/Expander/IsUrl.php
@@ -17,7 +17,7 @@ final class IsUrl implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/LowerThan.php
+++ b/src/Matcher/Pattern/Expander/LowerThan.php
@@ -22,7 +22,7 @@ final class LowerThan implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/LowerThan.php
+++ b/src/Matcher/Pattern/Expander/LowerThan.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class LowerThan implements PatternExpander
 {
+    const NAME = 'lowerThan';
+
     /**
      * @var
      */
@@ -16,6 +18,14 @@ final class LowerThan implements PatternExpander
      * @var null|string
      */
     private $error;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param $boundary

--- a/src/Matcher/Pattern/Expander/MatchRegex.php
+++ b/src/Matcher/Pattern/Expander/MatchRegex.php
@@ -22,7 +22,7 @@ final class MatchRegex implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/MatchRegex.php
+++ b/src/Matcher/Pattern/Expander/MatchRegex.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class MatchRegex implements PatternExpander
 {
+    const NAME = 'matchRegex';
+
     /**
      * @var null|string
      */
@@ -16,6 +18,14 @@ final class MatchRegex implements PatternExpander
      * @var string
      */
     private $pattern;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param string $pattern

--- a/src/Matcher/Pattern/Expander/OneOf.php
+++ b/src/Matcher/Pattern/Expander/OneOf.php
@@ -7,12 +7,22 @@ use Coduo\ToString\StringConverter;
 
 final class OneOf implements PatternExpander
 {
+    const NAME = 'oneOf';
+
     /**
      * @var PatternExpander[]
      */
     protected $expanders;
 
     protected $error;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     public function __construct()
     {

--- a/src/Matcher/Pattern/Expander/OneOf.php
+++ b/src/Matcher/Pattern/Expander/OneOf.php
@@ -19,7 +19,7 @@ final class OneOf implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/Optional.php
+++ b/src/Matcher/Pattern/Expander/Optional.php
@@ -11,7 +11,7 @@ final class Optional implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/Optional.php
+++ b/src/Matcher/Pattern/Expander/Optional.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+
+final class Optional implements PatternExpander
+{
+    const NAME = 'optional';
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function match($value)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getError()
+    {
+        return null;
+    }
+}

--- a/src/Matcher/Pattern/Expander/StartsWith.php
+++ b/src/Matcher/Pattern/Expander/StartsWith.php
@@ -27,7 +27,7 @@ final class StartsWith implements PatternExpander
     /**
      * {@inheritdoc}
      */
-    public static function is(string $name)
+    public static function is($name)
     {
         return self::NAME === $name;
     }

--- a/src/Matcher/Pattern/Expander/StartsWith.php
+++ b/src/Matcher/Pattern/Expander/StartsWith.php
@@ -7,6 +7,8 @@ use Coduo\ToString\StringConverter;
 
 final class StartsWith implements PatternExpander
 {
+    const NAME = 'startsWith';
+
     /**
      * @var
      */
@@ -21,6 +23,14 @@ final class StartsWith implements PatternExpander
      * @var bool
      */
     private $ignoreCase;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is(string $name)
+    {
+        return self::NAME === $name;
+    }
 
     /**
      * @param string $stringBeginning

--- a/src/Matcher/Pattern/Pattern.php
+++ b/src/Matcher/Pattern/Pattern.php
@@ -21,4 +21,13 @@ interface Pattern
      * @return null|string
      */
     public function getError();
+
+    /**
+     * Checks whether a Pattern has added Expander.
+     *
+     * @param string $expanderName The name of the expander
+     *
+     * @return bool true if the specified pattern has expander, false otherwise
+     */
+    public function hasExpander(string $expanderName);
 }

--- a/src/Matcher/Pattern/Pattern.php
+++ b/src/Matcher/Pattern/Pattern.php
@@ -29,5 +29,5 @@ interface Pattern
      *
      * @return bool true if the specified pattern has expander, false otherwise
      */
-    public function hasExpander(string $expanderName);
+    public function hasExpander($expanderName);
 }

--- a/src/Matcher/Pattern/PatternExpander.php
+++ b/src/Matcher/Pattern/PatternExpander.php
@@ -8,7 +8,7 @@ interface PatternExpander
      * @param string $name
      * @return bool
      */
-    public static function is(string $name);
+    public static function is($name);
 
     /**
      * @param $value

--- a/src/Matcher/Pattern/PatternExpander.php
+++ b/src/Matcher/Pattern/PatternExpander.php
@@ -5,6 +5,12 @@ namespace Coduo\PHPMatcher\Matcher\Pattern;
 interface PatternExpander
 {
     /**
+     * @param string $name
+     * @return bool
+     */
+    public static function is(string $name);
+
+    /**
      * @param $value
      * @return boolean
      */

--- a/src/Matcher/Pattern/TypePattern.php
+++ b/src/Matcher/Pattern/TypePattern.php
@@ -69,10 +69,24 @@ final class TypePattern implements Pattern
     }
 
     /**
-     * @return null|string
+     * {@inheritdoc}
      */
     public function getError()
     {
         return $this->error;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasExpander(string $expanderName)
+    {
+        foreach ($this->expanders as $expander) {
+            if ($expander::is($expanderName)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Matcher/Pattern/TypePattern.php
+++ b/src/Matcher/Pattern/TypePattern.php
@@ -79,7 +79,7 @@ final class TypePattern implements Pattern
     /**
      * {@inheritdoc}
      */
-    public function hasExpander(string $expanderName)
+    public function hasExpander($expanderName)
     {
         foreach ($this->expanders as $expander) {
             if ($expander::is($expanderName)) {

--- a/src/Parser/ExpanderInitializer.php
+++ b/src/Parser/ExpanderInitializer.php
@@ -2,35 +2,36 @@
 
 namespace Coduo\PHPMatcher\Parser;
 
-use Coduo\PHPMatcher\AST\Expander;
+use Coduo\PHPMatcher\AST\Expander as ExpanderNode;
 use Coduo\PHPMatcher\Exception\InvalidArgumentException;
 use Coduo\PHPMatcher\Exception\InvalidExpanderTypeException;
 use Coduo\PHPMatcher\Exception\UnknownExpanderClassException;
 use Coduo\PHPMatcher\Exception\UnknownExpanderException;
 use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander;
 
 final class ExpanderInitializer
 {
     /**
      * @var array
      */
-    private $expanderDefinitions = array(
-        "startsWith" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\StartsWith",
-        "endsWith" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\EndsWith",
-        "isNotEmpty" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsNotEmpty",
-        "isEmpty" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsEmpty",
-        "isDateTime" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsDateTime",
-        "isEmail" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsEmail",
-        "isUrl" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\IsUrl",
-        "lowerThan" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\LowerThan",
-        "greaterThan" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\GreaterThan",
-        "inArray" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\InArray",
-        "count" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\Count",
-        "contains" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\Contains",
-        "matchRegex" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\MatchRegex",
-
-        "oneOf" => "Coduo\\PHPMatcher\\Matcher\\Pattern\\Expander\\OneOf"
-    );
+    private $expanderDefinitions = [
+        Expander\Contains::NAME => Expander\Contains::class,
+        Expander\Count::NAME => Expander\Count::class,
+        Expander\EndsWith::NAME => Expander\EndsWith::class,
+        Expander\GreaterThan::NAME => Expander\GreaterThan::class,
+        Expander\InArray::NAME => Expander\InArray::class,
+        Expander\IsDateTime::NAME => Expander\IsDateTime::class,
+        Expander\IsEmail::NAME => Expander\IsEmail::class,
+        Expander\IsEmpty::NAME => Expander\IsEmpty::class,
+        Expander\IsNotEmpty::NAME => Expander\IsNotEmpty::class,
+        Expander\IsUrl::NAME => Expander\IsUrl::class,
+        Expander\LowerThan::NAME => Expander\LowerThan::class,
+        Expander\MatchRegex::NAME => Expander\MatchRegex::class,
+        Expander\OneOf::NAME => Expander\OneOf::class,
+        Expander\Optional::NAME => Expander\Optional::class,
+        Expander\StartsWith::NAME => Expander\StartsWith::class,
+    ];
 
     /**
      * @param string $expanderName
@@ -70,12 +71,12 @@ final class ExpanderInitializer
     }
 
     /**
-     * @param Expander $expanderNode
+     * @param ExpanderNode $expanderNode
      * @throws InvalidExpanderTypeException
      * @throws UnknownExpanderException
      * @return PatternExpander
      */
-    public function initialize(Expander $expanderNode)
+    public function initialize(ExpanderNode $expanderNode)
     {
         if (!array_key_exists($expanderNode->getName(), $this->expanderDefinitions)) {
             throw new UnknownExpanderException(sprintf("Unknown expander \"%s\"", $expanderNode->getName()));
@@ -86,7 +87,7 @@ final class ExpanderInitializer
         if ($expanderNode->hasArguments()) {
             $arguments = array();
             foreach ($expanderNode->getArguments() as $argument) {
-                $arguments[] = ($argument instanceof Expander)
+                $arguments[] = ($argument instanceof ExpanderNode)
                     ? $this->initialize($argument)
                     : $argument;
             }

--- a/tests/Matcher/Pattern/Expander/IsNotEmptyTest.php
+++ b/tests/Matcher/Pattern/Expander/IsNotEmptyTest.php
@@ -2,7 +2,6 @@
 
 namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
 
-use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Matcher\Pattern\Expander\IsNotEmpty;
 
 class IsNotEmptyTest extends \PHPUnit_Framework_TestCase

--- a/tests/Matcher/Pattern/Expander/OptionalTest.php
+++ b/tests/Matcher/Pattern/Expander/OptionalTest.php
@@ -4,7 +4,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
 
 use Coduo\PHPMatcher\Matcher\Pattern\Expander\Optional;
 
-class OptionalTest extends \PHPUnit\Framework\TestCase
+class OptionalTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider examplesProvider

--- a/tests/Matcher/Pattern/Expander/OptionalTest.php
+++ b/tests/Matcher/Pattern/Expander/OptionalTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\Optional;
+
+class OptionalTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_optional_expander_match($value, $expectedResult)
+    {
+        $expander = new Optional();
+        $this->assertEquals($expectedResult, $expander->match($value));
+    }
+
+    public static function examplesProvider()
+    {
+        return array(
+            array(array(), true),
+            array(array('data'), true),
+            array('', true),
+            array(0, true),
+            array(10.1, true),
+            array(null, true),
+            array('Lorem ipsum', true),
+        );
+    }
+}

--- a/tests/Matcher/Pattern/PatternTest.php
+++ b/tests/Matcher/Pattern/PatternTest.php
@@ -8,7 +8,7 @@ use Coduo\PHPMatcher\Matcher\Pattern\Expander\Optional;
 use Coduo\PHPMatcher\Matcher\Pattern\Pattern;
 use Coduo\PHPMatcher\Matcher\Pattern\TypePattern;
 
-class PatternTest  extends \PHPUnit\Framework\TestCase
+class PatternTest  extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Pattern

--- a/tests/Matcher/Pattern/PatternTest.php
+++ b/tests/Matcher/Pattern/PatternTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern;
+
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\IsEmail;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\IsEmpty;
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\Optional;
+use Coduo\PHPMatcher\Matcher\Pattern\Pattern;
+use Coduo\PHPMatcher\Matcher\Pattern\TypePattern;
+
+class PatternTest  extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Pattern
+     */
+    private $pattern;
+
+    public function setUp()
+    {
+        $this->pattern = new TypePattern('dummy');
+        $this->pattern->addExpander(new isEmail());
+        $this->pattern->addExpander(new isEmpty());
+        $this->pattern->addExpander(new Optional());
+    }
+
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_has_expander($expander, $expectedResult)
+    {
+        $this->assertEquals($expectedResult, $this->pattern->hasExpander($expander));
+    }
+
+    public static function examplesProvider()
+    {
+        return array(
+            array("isEmail", true),
+            array("isEmpty", true),
+            array("optional", true),
+            array("isUrl", false),
+            array("non existing expander", false),
+        );
+    }
+}


### PR DESCRIPTION
* Add optional expander definition

* Add hasExpander method for Pattern

* Allow mark JSON properties & xml nodes as optional

* Use intuitive matcher type definition in Xml test stock qty node definition

* Add information about optional Expander to README

* Remove return type declaration

* Catch PHPMatcher Exception when parsing pattern for optional values

* Add getName to PatternExpander interface

* Remove unncessary ExpanderInitializer dependency in TypePattern

* Use constants for expander name instead of method

* Redeclare $expanderDefinitions using constants

* Add static is($name) method to PatternExpander interface