### PR TITLE
2.3 - Add repeat expander feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ $matcher->getError(); // returns null or error message
 * ``oneOf(...$expanders)`` - example usage ``"@string@.oneOf(contains('foo'), contains('bar'), contains('baz'))"``
 * ``matchRegex($regex)`` - example usage ``"@string@.matchRegex('/^lorem.+/')"``
 * ``optional()`` - work's only with ``ArrayMatcher``, ``JsonMatcher`` and ``XmlMatcher``
+* ``repeat($pattern, $isStrict = true)`` - example usage ``'@array@.repeat({"name" => "foe"})'`` or ``"@array@.repeat('@string@')"``
 
 ##Example usage
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $matcher->getError(); // returns null or error message
 * ``oneOf(...$expanders)`` - example usage ``"@string@.oneOf(contains('foo'), contains('bar'), contains('baz'))"``
 * ``matchRegex($regex)`` - example usage ``"@string@.matchRegex('/^lorem.+/')"``
 * ``optional()`` - work's only with ``ArrayMatcher``, ``JsonMatcher`` and ``XmlMatcher``
-* ``repeat($pattern, $isStrict = true)`` - example usage ``'@array@.repeat({"name" => "foe"})'`` or ``"@array@.repeat('@string@')"``
+* ``repeat($pattern, $isStrict = true)`` - example usage ``'@array@.repeat({"name": "foe"})'`` or ``"@array@.repeat('@string@')"``
 
 ##Example usage
 

--- a/src/Matcher/Pattern/Expander/Repeat.php
+++ b/src/Matcher/Pattern/Expander/Repeat.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\ToString\StringConverter;
+
+final class Repeat implements PatternExpander
+{
+    const NAME = 'repeat';
+
+    /**
+     * @var null|string
+     */
+    private $error;
+
+    /**
+     * @var string
+     */
+    private $pattern;
+
+    /**
+     * @var bool
+     */
+    private $isStrict;
+
+    /**
+     * @var bool
+     */
+    private $isScalar;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function is($name)
+    {
+        return self::NAME === $name;
+    }
+
+    /**
+     * @param $value
+     */
+    public function __construct($pattern, $isStrict = true)
+    {
+        if (!is_string($pattern)) {
+            throw new \InvalidArgumentException("Repeat pattern must be a string.");
+        }
+
+        $this->pattern = $pattern;
+        $this->isStrict = $isStrict;
+        $this->isScalar = true;
+
+        $json = json_decode($pattern, true);
+
+        if ($json !== null && json_last_error() === JSON_ERROR_NONE) {
+            $this->pattern = $json;
+            $this->isScalar = false;
+        }
+    }
+
+    /**
+     * @param $values
+     * @return bool
+     */
+    public function match($values)
+    {
+        if (!is_array($values)) {
+            $this->error = sprintf("Repeat expander require \"array\", got \"%s\".", new StringConverter($values));
+            return false;
+        }
+
+        $factory = new SimpleFactory();
+        $matcher = $factory->createMatcher();
+
+        if ($this->isScalar) {
+            return $this->matchScalar($values, $matcher);
+        }
+
+        return $this->matchJson($values, $matcher);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * @param array $values
+     * @param Matcher $matcher
+     * @return bool
+     */
+    private function matchScalar(array $values, Matcher $matcher)
+    {
+        foreach ($values as $index => $value) {
+            $match = $matcher->match($value, $this->pattern);
+
+            if (!$match) {
+                $this->error = sprintf("Repeat expander, entry n°%d, find error : %s", $index, $matcher->getError());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array $values
+     * @param Matcher $matcher
+     * @return bool
+     */
+    private function matchJson(array $values, Matcher $matcher)
+    {
+        $patternKeys = array_keys($this->pattern);
+        $patternKeysLength = count($patternKeys);
+
+        foreach ($values as $index => $value) {
+            $valueKeys = array_keys($value);
+            $valueKeysLength = count($valueKeys);
+
+            if ($this->isStrict && $patternKeysLength !== $valueKeysLength) {
+                $this->error = sprintf("Repeat expander expect to have %d keys in array but get : %d", $patternKeysLength, $valueKeysLength);
+                return false;
+            }
+
+            foreach ($patternKeys as $key) {
+                if (!array_key_exists($key, $value)) {
+                    $this->error = sprintf("Repeat expander, entry n°%d, require \"array\" to have key \"%s\".", $index, $key);
+                    return false;
+                }
+
+                $match = $matcher->match($value[$key], $this->pattern[$key]);
+
+                if (!$match) {
+                    $this->error = sprintf("Repeat expander, entry n°%d, key \"%s\", find error : %s", $index, $key, $matcher->getError());
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Parser/ExpanderInitializer.php
+++ b/src/Parser/ExpanderInitializer.php
@@ -31,6 +31,7 @@ final class ExpanderInitializer
         Expander\OneOf::NAME => Expander\OneOf::class,
         Expander\Optional::NAME => Expander\Optional::class,
         Expander\StartsWith::NAME => Expander\StartsWith::class,
+        Expander\Repeat::NAME => Expander\Repeat::class,
     ];
 
     /**

--- a/tests/Matcher/Pattern/Expander/RepeatTest.php
+++ b/tests/Matcher/Pattern/Expander/RepeatTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\Repeat;
+
+class RepeatTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider examplesProvider
+     */
+    public function test_matching_values($needle, $haystack, $expectedResult, $isStrict = true)
+    {
+        $expander = new Repeat($needle, $isStrict);
+        $this->assertEquals($expectedResult, $expander->match($haystack));
+    }
+
+    public static function examplesProvider()
+    {
+        $jsonPattern = '{"name": "@string@", "activated": "@boolean@"}';
+
+        $jsonTest = array(
+            array("name" => "toto", "activated" => true),
+            array("name" => "titi", "activated" => false),
+            array("name" => "tate", "activated" => true)
+        );
+
+        $scalarPattern = "@string@";
+        $scalarTest = array(
+            "toto",
+            "titi",
+            "tata"
+        );
+
+        $strictTest = array(
+            array("name" => "toto", "activated" => true, "offset" => "offset")
+        );
+
+        return array(
+            array($jsonPattern, $jsonTest, true),
+            array($scalarPattern, $scalarTest, true),
+            array($jsonPattern, $strictTest, true, false)
+        );
+    }
+
+    /**
+     * @dataProvider invalidCasesProvider
+     */
+    public function test_error_when_matching_fail($boundary, $value, $errorMessage)
+    {
+        $expander = new Repeat($boundary);
+        $this->assertFalse($expander->match($value));
+        $this->assertEquals($errorMessage, $expander->getError());
+    }
+
+    public static function invalidCasesProvider()
+    {
+        $pattern = '{"name": "@string@", "activated": "@boolean@"}';
+
+        $valueTest = array(
+            array("name" => 1, "activated" => "yes")
+        );
+
+        $keyTest = array(
+            array("offset" => true, "foe" => "bar")
+        );
+
+        $strictTest = array(
+            array("name" => 1, "activated" => "yes", "offset" => true)
+        );
+
+        return array(
+            array($pattern, $valueTest, 'Repeat expander, entry n°0, key "name", find error : integer "1" is not a valid string.'),
+            array($pattern, $keyTest, 'Repeat expander, entry n°0, require "array" to have key "name".'),
+            array($pattern, $strictTest, 'Repeat expander expect to have 2 keys in array but get : 3')
+        );
+    }
+}

--- a/tests/Matcher/Pattern/Expander/RepeatTest.php
+++ b/tests/Matcher/Pattern/Expander/RepeatTest.php
@@ -72,7 +72,8 @@ class RepeatTest extends \PHPUnit_Framework_TestCase
         return array(
             array($pattern, $valueTest, 'Repeat expander, entry n°0, key "name", find error : integer "1" is not a valid string.'),
             array($pattern, $keyTest, 'Repeat expander, entry n°0, require "array" to have key "name".'),
-            array($pattern, $strictTest, 'Repeat expander expect to have 2 keys in array but get : 3')
+            array($pattern, $strictTest, 'Repeat expander expect to have 2 keys in array but get : 3'),
+            array($pattern, "", 'Repeat expander require "array", got "".')
         );
     }
 }


### PR DESCRIPTION
Add "repeat" requested feature in:
https://github.com/coduo/php-matcher/issues/35

And also in:
https://github.com/coduo/php-matcher/issues/21

Feel free to comment, give advice.
I want to merge on 2.3 because I want to stick with PHP 5.6 not 7.