### PR TITLE
Matcher fails when trying to use empty string as a pattern

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -46,6 +46,10 @@ final class Parser
 
     public function getAST(string $pattern) : AST\Pattern
     {
+        if($pattern === '') {
+            return new AST\Pattern(new AST\Type(''));
+        }
+
         $this->lexer->setInput($pattern);
         return $this->getPattern();
     }

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -421,4 +421,32 @@ XML;
             ],
         ];
     }
+
+    public static function emptyPatternString()
+    {
+        return [
+            [
+                '', '', true,
+                '123', '', false,
+                ' ', '', false,
+                null, '', false,
+                1, '', false,
+                0, '', false,
+                '{"name": "123"}', '{"name": ""}', false,
+                '{"name": ""}', '{"name": ""}', true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider emptyPatternString
+     */
+    public function test_empty_pattern_in_the_json($value, $pattern, $expectedResult)
+    {
+        $factory = new SimpleFactory();
+        $matcher = $factory->createMatcher();
+
+        $match = $matcher->match($value, $pattern);
+        $this->assertSame($expectedResult, $match);
+    }
 }


### PR DESCRIPTION
Using value like:

`{"name": "123"}`

for pattern: 

`{"name": ""}`

results in:

```
TypeError: Argument 1 passed to Coduo\PHPMatcher\Parser::unexpectedSyntaxError() must be of the type array, null given, called in /home/jacek/workspace/php-matcher/src/Parser.php on line 66

/home/jacek/workspace/php-matcher/src/Parser.php:252
/home/jacek/workspace/php-matcher/src/Parser.php:66
/home/jacek/workspace/php-matcher/src/Parser.php:54
/home/jacek/workspace/php-matcher/src/Parser.php:29
/home/jacek/workspace/php-matcher/src/Matcher/StringMatcher.php:43
/home/jacek/workspace/php-matcher/src/Matcher/ChainMatcher.php:32
/home/jacek/workspace/php-matcher/src/Matcher/ChainMatcher.php:33
/home/jacek/workspace/php-matcher/src/Matcher/ArrayMatcher.php:165
/home/jacek/workspace/php-matcher/src/Matcher/ArrayMatcher.php:88
/home/jacek/workspace/php-matcher/src/Matcher/ArrayMatcher.php:46
/home/jacek/workspace/php-matcher/src/Matcher/ChainMatcher.php:33
/home/jacek/workspace/php-matcher/src/Matcher/JsonMatcher.php:35
/home/jacek/workspace/php-matcher/src/Matcher/ChainMatcher.php:33
/home/jacek/workspace/php-matcher/src/Matcher.php:20
/home/jacek/workspace/php-matcher/tests/MatcherTest.php:448
```
The problem seems to be in the doctrine's `AbstractLexer::scan($input):245` that is unable to detect the empty string, therefore the `$this->lexer->lookahead` used in `Parser:61` is `null`, and that causes the `TypeError: Argument 1 passed to Coduo\PHPMatcher\Parser::unexpectedSyntaxError() must be of the type array, null given` when trying to raise the `unexpectedSyntaxError` (`PatternException`).

I am not very familiar with doctrine's lexer; I tried to force it to detect the empty string by modifying `getCatchablePatterns` but with no results - though I think, It might be possible.