### PR TITLE
Trim whitespaces around the matchers after `OR` splitting

### DIFF
--- a/src/Matcher/OrMatcher.php
+++ b/src/Matcher/OrMatcher.php
@@ -18,6 +18,8 @@ final class OrMatcher extends Matcher
     public function match($value, $pattern) : bool
     {
         $patterns = \explode('||', $pattern);
+        $patterns = \array_map('trim', $patterns);
+
         foreach ($patterns as $childPattern) {
             if ($this->matchChild($value, $childPattern)) {
                 return true;

--- a/tests/Matcher/OrMatcherTest.php
+++ b/tests/Matcher/OrMatcherTest.php
@@ -43,6 +43,21 @@ class OrMatcherTest extends TestCase
         );
     }
 
+    public function test_whitespaces_trim_after_splitting()
+    {
+        $this->assertTrue(
+            $this->matcher->match(
+                [
+                    'test' => null
+                ],
+                [
+                    'test' => ' @integer@ || @null@ '
+                ]
+            ),
+            $this->matcher->getError()
+        );
+    }
+
     public static function positiveMatchData()
     {
         $simpleArr = [


### PR DESCRIPTION
`OR` matcher was added to `2.x` version. So the same PR must be added to `2.x` branches as well.