### PR TITLE
Fix return type-hint

### DIFF
--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -27,7 +27,7 @@ final class PHPMatcherConstraint extends Constraint
         return 'matches the pattern';
     }
 
-    protected function additionalFailureDescription($other)
+    protected function additionalFailureDescription($other) : string
     {
         return $this->matcher->getError();
     }


### PR DESCRIPTION
While using the PHPUnit test helper we get this error 

```
PHP Fatal error:  Declaration of Coduo\PHPMatcher\PHPUnit\PHPMatcherConstraint::additionalFailureDescription($other) must be compatible with PHPUnit\Framework\Constraint\Constraint::additionalFailureDescription($other): string in /home/vagrant/code/vendor/coduo/php-matcher/src/PHPUnit/PHPMatcherConstraint.php on line 11
2018-03-23T23:25:18+00:00 [critical] Fatal Compile Error: Declaration of Coduo\PHPMatcher\PHPUnit\PHPMatcherConstraint::additionalFailureDescription($other) must be compatible with PHPUnit\Framework\Constraint\Constraint::additionalFailureDescription($other): string
```

```
Fatal error: Declaration of Coduo\PHPMatcher\PHPUnit\PHPMatcherConstraint::additionalFailureDescription($other) must be compatible with PHPUnit\Framework\Constraint\Constraint::additionalFailureDescription($other): string in /home/vagrant/code/vendor/coduo/php-matcher/src/PHPUnit/PHPMatcherConstraint.php on line 11
```