### PR TITLE
Added UUID pattern support for the TextMatcher

### DIFF
--- a/src/Matcher/Pattern/RegexConverter.php
+++ b/src/Matcher/Pattern/RegexConverter.php
@@ -21,6 +21,8 @@ final class RegexConverter
                 return '(\\-?[0-9]*)';
             case 'double':
                 return '(\\-?[0-9]*[\\.|\\,][0-9]*)';
+            case 'uuid':
+                return "([\da-f]{8}-[\da-f]{4}-[1-5][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12})";
             default:
                 throw new UnknownTypeException($typePattern->getType());
         }

--- a/src/Matcher/Pattern/RegexConverter.php
+++ b/src/Matcher/Pattern/RegexConverter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Matcher\Pattern;
 
 use Coduo\PHPMatcher\Exception\UnknownTypeException;
+use Coduo\PHPMatcher\Matcher\UuidMatcher;
 
 final class RegexConverter
 {
@@ -22,7 +23,7 @@ final class RegexConverter
             case 'double':
                 return '(\\-?[0-9]*[\\.|\\,][0-9]*)';
             case 'uuid':
-                return "([\da-f]{8}-[\da-f]{4}-[1-5][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12})";
+                return '('.UuidMatcher::UUID_PATTERN.')';
             default:
                 throw new UnknownTypeException($typePattern->getType());
         }

--- a/src/Matcher/UuidMatcher.php
+++ b/src/Matcher/UuidMatcher.php
@@ -10,7 +10,8 @@ use Coduo\ToString\StringConverter;
 final class UuidMatcher extends Matcher
 {
     const PATTERN = 'uuid';
-    const UUID_FORMAT_PATTERN = '|^[\da-f]{8}-[\da-f]{4}-[1-5][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$|';
+    const UUID_PATTERN = '[\da-f]{8}-[\da-f]{4}-[1-5][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}';
+    const UUID_FORMAT_PATTERN = '|^'.self::UUID_PATTERN.'$|';
 
     private $parser;
 

--- a/tests/Matcher/TextMatcherTest.php
+++ b/tests/Matcher/TextMatcherTest.php
@@ -107,6 +107,16 @@ XML;
                 '/users/12345/active',
                 '/users/@integer@.greaterThan(0)/active',
                 true
+            ],
+            [
+                '/user/ebd1fb0e-45ae-11e8-842f-0ed5f89f718b/profile',
+                '/user/@uuid@/@string@',
+                true
+            ],
+            [
+                '/user/12345/profile',
+                '/user/@uuid@/@string@',
+                false
             ]
         ];
     }


### PR DESCRIPTION
This PR resolves the #112 issue. It enables to use the `@uuid@` pattern with the `TextMatcher`.

This pattern is actually not supported : `Type pattern "@uuid@" is not supported by TextMatcher.`

After this patch, we can use : 

```
if (!PHPMatcher::match("/user/ebd1fb0e-45ae-11e8-842f-0ed5f89f718b/profile", "/user/@uuid@/profile", $error)) {
    echo $error;
} else {
    echo "Matched.";
}
```