### PR TITLE
Added isIp() pattern expander

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $matcher->getError(); // returns null or error message
 * ``isDateTime()``
 * ``isEmail()``
 * ``isUrl()``
+* ``isIp()``
 * ``isEmpty()``
 * ``isNotEmpty()``
 * ``lowerThan($boundry)``

--- a/src/Matcher/Pattern/Expander/IsIp.php
+++ b/src/Matcher/Pattern/Expander/IsIp.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
+use Coduo\ToString\StringConverter;
+
+final class IsIp implements PatternExpander
+{
+    const NAME = 'isIp';
+
+    private $error;
+
+    public static function is(string $name) : bool
+    {
+        return self::NAME === $name;
+    }
+
+    public function match($value) : bool
+    {
+        if (false === \is_string($value)) {
+            $this->error = \sprintf('IsIp expander require "string", got "%s".', new StringConverter($value));
+            return false;
+        }
+
+        if (false === $this->matchValue($value)) {
+            $this->error = \sprintf('string "%s" is not a valid IP address.', $value);
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    private function matchValue(string $value) : bool
+    {
+        try {
+            return false !== \filter_var($value, FILTER_VALIDATE_IP);
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}

--- a/src/Parser/ExpanderInitializer.php
+++ b/src/Parser/ExpanderInitializer.php
@@ -25,6 +25,7 @@ final class ExpanderInitializer
         Expander\IsEmpty::NAME => Expander\IsEmpty::class,
         Expander\IsNotEmpty::NAME => Expander\IsNotEmpty::class,
         Expander\IsUrl::NAME => Expander\IsUrl::class,
+        Expander\IsIp::NAME => Expander\IsIp::class,
         Expander\LowerThan::NAME => Expander\LowerThan::class,
         Expander\MatchRegex::NAME => Expander\MatchRegex::class,
         Expander\OneOf::NAME => Expander\OneOf::class,

--- a/tests/Matcher/Pattern/Expander/IsIpTest.php
+++ b/tests/Matcher/Pattern/Expander/IsIpTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Tests\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Matcher\Pattern\Expander\IsIp;
+use PHPUnit\Framework\TestCase;
+
+class IsIpTest extends TestCase
+{
+    /**
+     * @dataProvider examplesIpProvider
+     */
+    public function test_ip($ip, $expected)
+    {
+        $expander = new IsIp();
+        $this->assertEquals($expected, $expander->match($ip));
+    }
+
+    public static function examplesIpProvider()
+    {
+        return [
+            ['127.0.0.1', true],
+            ['255.255.255.255', true],
+            ['2001:0db8:0000:42a1:0000:0000:ab1c:0001', true],
+            ['999.999.999.999', false],
+            ['127.127', false],
+            ['foo:bar:42:42', false]
+        ];
+    }
+}

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -384,6 +384,10 @@ XML;
             [[], ['unexistent_key' => '@uuid@.optional()'], true],
             [[], ['unexistent_key' => '@xml@.optional()'], true],
             [['Norbert', 'Michał'], '@array@.repeat("@string@")', true],
+            ['127.0.0.1', '@string@.isIp()', true],
+            ['2001:0db8:0000:42a1:0000:0000:ab1c:0001', '@string@.isIp()', true],
+            ['127.255.999.999', '@string@.isIp()', false],
+            ['foo:bar:42:42', '@string@.isIp()', false],
         ];
     }
 


### PR DESCRIPTION
This PR adds an ``isIp()``pattern expander, it is based on the PHP filter extension.
This pattern checks IPv4 and IPv6 addresses within public, private and reserved range.

Example usage : 

``` 
if (!PHPMatcher::match("127.0.0.1", "@string@.isIp()", $error)) {
    echo $error;
} else {
    echo "Matched.";
}
 ```