### PR TITLE
Matcher modifiers

### DIFF
--- a/src/Exception/UnknownModifierClassException.php
+++ b/src/Exception/UnknownModifierClassException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Exception;
+
+class UnknownModifierClassException extends \Exception
+{
+    public function __construct(string $name, string $class)
+    {
+        parent::__construct(\sprintf(
+            'Unknown class %s for modifier %s',
+            $class,
+            $name
+        ));
+    }
+}

--- a/src/Exception/UnknownModifierException.php
+++ b/src/Exception/UnknownModifierException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Exception;
+
+class UnknownModifierException extends Exception
+{
+}

--- a/src/Factory/SimpleFactory.php
+++ b/src/Factory/SimpleFactory.php
@@ -21,12 +21,14 @@ class SimpleFactory implements Factory
         $scalarMatchers = $this->buildScalarMatchers();
         $orMatcher = $this->buildOrMatcher();
 
+        $parser = $this->buildParser();
+
         $chainMatcher = new Matcher\ChainMatcher([
             $scalarMatchers,
             $orMatcher,
-            new Matcher\JsonMatcher($orMatcher),
+            new Matcher\JsonMatcher($orMatcher, $parser),
             new Matcher\XmlMatcher($orMatcher),
-            new Matcher\TextMatcher($scalarMatchers, $this->buildParser())
+            new Matcher\TextMatcher($scalarMatchers, $parser)
         ]);
 
         return $chainMatcher;
@@ -76,6 +78,6 @@ class SimpleFactory implements Factory
 
     protected function buildParser() : Parser
     {
-        return new Parser(new Lexer(), new Parser\ExpanderInitializer());
+        return new Parser(new Lexer(), new Parser\ExpanderInitializer(), new Parser\ModifiersRegistry());
     }
 }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -20,6 +20,7 @@ final class Lexer extends AbstractLexer
     const T_COMMA  = 10;
     const T_COLON = 11;
     const T_TYPE_PATTERN = 12;
+    const T_MODIFIERS_NAMES = 13;
 
     /**
      * Lexical catchable patterns.
@@ -33,6 +34,7 @@ final class Lexer extends AbstractLexer
             "'(?:[^']|'')*'", // string between ' character
             '"(?:[^"]|"")*"', // string between " character,
             '@[a-zA-Z0-9\\*]+@', // type pattern
+            Parser::MODIFIERS_REGEX, // modifiers names
         ];
     }
 
@@ -102,6 +104,10 @@ final class Lexer extends AbstractLexer
             return self::T_EXPANDER_NAME;
         }
 
+        if ($this->isModifierNamesToken($value)) {
+            return self::T_MODIFIERS_NAMES;
+        }
+
         return $type;
     }
 
@@ -133,5 +139,10 @@ final class Lexer extends AbstractLexer
     protected function isTypePatternToken(string $value) : bool
     {
         return \substr($value, 0, 1) === '@' && \substr($value, \strlen($value) - 1, 1) === '@' && \strlen($value) > 1;
+    }
+
+    protected function isModifierNamesToken(string $value) : bool
+    {
+        return \substr($value, 0, 1) === '|' && \substr($value, \strlen($value) - 1, 1) === '|' && \strlen($value) > 2;
     }
 }

--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -72,15 +72,15 @@ final class ArrayMatcher extends ModifiableMatcher
 
     public function supportedModifiers(): array
     {
-        return \array_keys(self::SUPPORTED_MODIFIERS);
+        return self::SUPPORTED_MODIFIERS;
     }
 
-    public function getMatchers(): iterable
+    public function getMatchers(): array
     {
         return [$this->propertyMatcher];
     }
 
-    public function applyModifier(MatcherModifier $modifier): void
+    public function applyModifier(MatcherModifier $modifier)
     {
         switch ($modifier->getName()) {
             case IgnoreExtraKeys::NAME:

--- a/src/Matcher/BooleanMatcher.php
+++ b/src/Matcher/BooleanMatcher.php
@@ -34,6 +34,6 @@ final class BooleanMatcher extends Matcher
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        return $this->parser->hasValidSyntax($pattern) && $this->parser->parseTypePattern($pattern)->is(self::PATTERN);
     }
 }

--- a/src/Matcher/ChainMatcher.php
+++ b/src/Matcher/ChainMatcher.php
@@ -61,12 +61,12 @@ final class ChainMatcher extends ModifiableMatcher
         return \array_keys(ModifiersRegistry::BUILT_IN_MODIFIERS);
     }
 
-    public function getMatchers(): iterable
+    public function getMatchers(): array
     {
         return $this->matchers;
     }
 
-    public function applyModifier(MatcherModifier $modifier): void
+    public function applyModifier(MatcherModifier $modifier)
     {
 
     }

--- a/src/Matcher/ChainMatcher.php
+++ b/src/Matcher/ChainMatcher.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Matcher\Modifier\MatcherModifier;
+use Coduo\PHPMatcher\Parser\ModifiersRegistry;
 use Coduo\ToString\StringConverter;
 
-final class ChainMatcher extends Matcher
+final class ChainMatcher extends ModifiableMatcher
 {
     /**
      * @var ValueMatcher[]
@@ -52,5 +54,20 @@ final class ChainMatcher extends Matcher
     public function canMatch($pattern) : bool
     {
         return true;
+    }
+
+    public function supportedModifiers(): array
+    {
+        return \array_keys(ModifiersRegistry::BUILT_IN_MODIFIERS);
+    }
+
+    public function getMatchers(): iterable
+    {
+        return $this->matchers;
+    }
+
+    public function applyModifier(MatcherModifier $modifier): void
+    {
+
     }
 }

--- a/src/Matcher/DoubleMatcher.php
+++ b/src/Matcher/DoubleMatcher.php
@@ -25,7 +25,7 @@ final class DoubleMatcher extends Matcher
             return false;
         }
 
-        $typePattern = $this->parser->parse($pattern);
+        $typePattern = $this->parser->parseTypePattern($pattern);
         if (!$typePattern->matchExpanders($value)) {
             $this->error = $typePattern->getError();
             return false;
@@ -40,6 +40,6 @@ final class DoubleMatcher extends Matcher
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        return $this->parser->hasValidSyntax($pattern) && $this->parser->parseTypePattern($pattern)->is(self::PATTERN);
     }
 }

--- a/src/Matcher/IntegerMatcher.php
+++ b/src/Matcher/IntegerMatcher.php
@@ -25,7 +25,7 @@ final class IntegerMatcher extends Matcher
             return false;
         }
 
-        $typePattern = $this->parser->parse($pattern);
+        $typePattern = $this->parser->parseTypePattern($pattern);
         if (!$typePattern->matchExpanders($value)) {
             $this->error = $typePattern->getError();
             return false;
@@ -40,6 +40,6 @@ final class IntegerMatcher extends Matcher
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        return $this->parser->hasValidSyntax($pattern) && $this->parser->parseTypePattern($pattern)->is(self::PATTERN);
     }
 }

--- a/src/Matcher/JsonMatcher.php
+++ b/src/Matcher/JsonMatcher.php
@@ -79,12 +79,12 @@ final class JsonMatcher extends ModifiableMatcher
         return \array_keys(self::SUPPORTED_MODIFIERS);
     }
 
-    public function getMatchers(): iterable
+    public function getMatchers(): array
     {
         return [$this->matcher];
     }
 
-    public function applyModifier(MatcherModifier $modifier): void
+    public function applyModifier(MatcherModifier $modifier)
     {
     }
 

--- a/src/Matcher/ModifiableMatcher.php
+++ b/src/Matcher/ModifiableMatcher.php
@@ -34,7 +34,7 @@ abstract class ModifiableMatcher implements ModifiableValueMatcher
         return \in_array($modifier->getName(), $this->supportedModifiers(), true);
     }
 
-    public function modify(MatcherModifier $modifier): void
+    public function modify(MatcherModifier $modifier)
     {
         foreach ($this->getMatchers() as $matcher) {
             if ($matcher instanceof ModifiableValueMatcher && $matcher->supportsModifier($modifier)) {
@@ -47,9 +47,12 @@ abstract class ModifiableMatcher implements ModifiableValueMatcher
     abstract public function supportedModifiers(): array;
 
     /**
-     * @return iterable|ValueMatcher[]
+     * @return ValueMatcher[]
      */
-    abstract public function getMatchers(): iterable;
+    abstract public function getMatchers(): array;
 
-    abstract public function applyModifier(MatcherModifier $modifier): void;
+    /**
+     * @return void
+     */
+    abstract public function applyModifier(MatcherModifier $modifier);
 }

--- a/src/Matcher/ModifiableMatcher.php
+++ b/src/Matcher/ModifiableMatcher.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Matcher;
+
+use Coduo\PHPMatcher\Matcher\Modifier\MatcherModifier;
+
+abstract class ModifiableMatcher implements ModifiableValueMatcher
+{
+    protected $error;
+
+    /**
+     * @inheritdoc
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function match($value, $pattern) : bool
+    {
+        if ($value === $pattern) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function supportsModifier(MatcherModifier $modifier): bool
+    {
+        return \in_array($modifier->getName(), $this->supportedModifiers(), true);
+    }
+
+    public function modify(MatcherModifier $modifier): void
+    {
+        foreach ($this->getMatchers() as $matcher) {
+            if ($matcher instanceof ModifiableValueMatcher && $matcher->supportsModifier($modifier)) {
+                $matcher->modify($modifier);
+            }
+        }
+        $this->applyModifier($modifier);
+    }
+
+    abstract public function supportedModifiers(): array;
+
+    /**
+     * @return iterable|ValueMatcher[]
+     */
+    abstract public function getMatchers(): iterable;
+
+    abstract public function applyModifier(MatcherModifier $modifier): void;
+}

--- a/src/Matcher/ModifiableValueMatcher.php
+++ b/src/Matcher/ModifiableValueMatcher.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Matcher;
+
+use Coduo\PHPMatcher\Matcher\Modifier\MatcherModifier;
+
+interface ModifiableValueMatcher extends ValueMatcher
+{
+    public function supportsModifier(MatcherModifier $modifier) : bool;
+
+    public function modify(MatcherModifier $modifier) : void;
+}

--- a/src/Matcher/ModifiableValueMatcher.php
+++ b/src/Matcher/ModifiableValueMatcher.php
@@ -7,7 +7,10 @@ use Coduo\PHPMatcher\Matcher\Modifier\MatcherModifier;
 
 interface ModifiableValueMatcher extends ValueMatcher
 {
-    public function supportsModifier(MatcherModifier $modifier) : bool;
+    public function supportsModifier(MatcherModifier $modifier): bool;
 
-    public function modify(MatcherModifier $modifier) : void;
+    /**
+     * @return void
+     */
+    public function modify(MatcherModifier $modifier);
 }

--- a/src/Matcher/Modifier/CaseInsensitive.php
+++ b/src/Matcher/Modifier/CaseInsensitive.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Matcher\Modifier;
+
+final class CaseInsensitive implements MatcherModifier
+{
+    const NAME = 'case_insensitive';
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/Matcher/Modifier/IgnoreExtraKeys.php
+++ b/src/Matcher/Modifier/IgnoreExtraKeys.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Matcher\Modifier;
+
+final class IgnoreExtraKeys implements MatcherModifier
+{
+    const NAME = 'ignore_extra_keys';
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/Matcher/Modifier/MatcherModifier.php
+++ b/src/Matcher/Modifier/MatcherModifier.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Matcher\Modifier;
+
+interface MatcherModifier
+{
+    public function getName() : string;
+}

--- a/src/Matcher/NumberMatcher.php
+++ b/src/Matcher/NumberMatcher.php
@@ -34,6 +34,6 @@ final class NumberMatcher extends Matcher
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        return $this->parser->hasValidSyntax($pattern) && $this->parser->parseTypePattern($pattern)->is(self::PATTERN);
     }
 }

--- a/src/Matcher/ScalarMatcher.php
+++ b/src/Matcher/ScalarMatcher.php
@@ -4,14 +4,38 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Matcher\Modifier\CaseInsensitive;
+use Coduo\PHPMatcher\Matcher\Modifier\MatcherModifier;
 use Coduo\ToString\StringConverter;
 
-final class ScalarMatcher extends Matcher
+final class ScalarMatcher extends ModifiableMatcher
 {
+    const SUPPORTED_MODIFIERS = [
+        CaseInsensitive::NAME
+    ];
+
+    /** @var bool */
+    private $caseInsensitive;
+
+    public function __construct()
+    {
+        $this->caseInsensitive = false;
+    }
+
     public function match($value, $pattern) : bool
     {
-        if ($value !== $pattern) {
-            $this->error = \sprintf('"%s" does not match "%s".', new StringConverter($value), new StringConverter($pattern));
+        if (!$this->caseInsensitive && $value !== $pattern) {
+            $this->setError('does not match', $value, $pattern);
+            return false;
+        }
+
+        if (
+            $this->caseInsensitive
+            && \is_string($value)
+            && \is_string($pattern)
+            && \strcasecmp($value, $pattern) !== 0
+        ) {
+            $this->setError('does not case-insensitive match', $value, $pattern);
             return false;
         }
 
@@ -21,5 +45,32 @@ final class ScalarMatcher extends Matcher
     public function canMatch($pattern) : bool
     {
         return \is_scalar($pattern);
+    }
+
+    public function supportedModifiers(): array
+    {
+        return self::SUPPORTED_MODIFIERS;
+    }
+
+    public function getMatchers(): array
+    {
+        return [];
+    }
+
+    public function applyModifier(MatcherModifier $modifier)
+    {
+        switch ($modifier->getName()) {
+            case CaseInsensitive::NAME:
+                $this->caseInsensitive= true;
+                break;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function setError(string $message, $value, $pattern)
+    {
+        $this->error = \sprintf('"%s" ' . $message . ' "%s".', new StringConverter($value), new StringConverter($pattern));
     }
 }

--- a/src/Matcher/StringMatcher.php
+++ b/src/Matcher/StringMatcher.php
@@ -25,7 +25,7 @@ final class StringMatcher extends Matcher
             return false;
         }
 
-        $typePattern = $this->parser->parse($pattern);
+        $typePattern = $this->parser->parseTypePattern($pattern);
         if (!$typePattern->matchExpanders($value)) {
             $this->error = $typePattern->getError();
             return false;
@@ -40,6 +40,6 @@ final class StringMatcher extends Matcher
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        return $this->parser->hasValidSyntax($pattern) && $this->parser->parseTypePattern($pattern)->is(self::PATTERN);
     }
 }

--- a/src/Matcher/TextMatcher.php
+++ b/src/Matcher/TextMatcher.php
@@ -116,7 +116,7 @@ final class TextMatcher extends Matcher
         \preg_match_all(self::PATTERN_REGEXP, $patternRegex, $matches);
 
         foreach ($matches[0] as $index => $typePatternString) {
-            $typePattern = $this->parser->parse($typePatternString);
+            $typePattern = $this->parser->parseTypePattern($typePatternString);
             $patternsReplacedWithRegex[] = $typePattern;
             $patternRegex = \str_replace(
                 $typePatternString,

--- a/src/Matcher/UuidMatcher.php
+++ b/src/Matcher/UuidMatcher.php
@@ -49,6 +49,6 @@ final class UuidMatcher extends Matcher
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        return $this->parser->hasValidSyntax($pattern) && $this->parser->parseTypePattern($pattern)->is(self::PATTERN);
     }
 }

--- a/src/Matcher/ValueMatcher.php
+++ b/src/Matcher/ValueMatcher.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Matcher\Modifier\MatcherModifier;
+
 interface ValueMatcher
 {
     /**

--- a/src/Matcher/ValueMatcher.php
+++ b/src/Matcher/ValueMatcher.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
-use Coduo\PHPMatcher\Matcher\Modifier\MatcherModifier;
-
 interface ValueMatcher
 {
     /**

--- a/src/Parser/ModifiersRegistry.php
+++ b/src/Parser/ModifiersRegistry.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Parser;
+
+use Coduo\PHPMatcher\Exception\UnknownModifierClassException;
+use Coduo\PHPMatcher\Exception\UnknownModifierException;
+use Coduo\PHPMatcher\Matcher\Modifier;
+
+final class ModifiersRegistry
+{
+    /**
+     * @var array
+     */
+    private $modifiers = [];
+
+    public const BUILT_IN_MODIFIERS = [
+        Modifier\IgnoreExtraKeys::NAME => Modifier\IgnoreExtraKeys::class,
+        Modifier\CaseInsensitive::NAME => Modifier\CaseInsensitive::class
+    ];
+
+    public function __construct()
+    {
+        $this->modifiers = self::BUILT_IN_MODIFIERS;
+    }
+
+    public function register(string $name, string $class): void
+    {
+        if (!\class_exists($class) || \is_a($class, Modifier\MatcherModifier::class, true)) {
+            throw new UnknownModifierClassException($name, $class);
+        }
+
+        $this->modifiers[$name] = $class;
+    }
+
+    public function has(string $name) : bool
+    {
+        return \array_key_exists($name, $this->modifiers);
+    }
+
+    public function get(string $name) : Modifier\MatcherModifier
+    {
+        if (!$this->has($name)) {
+            throw new UnknownModifierException($name);
+        }
+
+        return $this->initialize($name);
+    }
+
+    private function initialize(string $name): Modifier\MatcherModifier
+    {
+        $reflection = new \ReflectionClass($this->modifiers[$name]);
+
+        return $reflection->newInstance();
+    }
+}

--- a/src/Parser/ModifiersRegistry.php
+++ b/src/Parser/ModifiersRegistry.php
@@ -14,7 +14,7 @@ final class ModifiersRegistry
      */
     private $modifiers = [];
 
-    public const BUILT_IN_MODIFIERS = [
+    const BUILT_IN_MODIFIERS = [
         Modifier\IgnoreExtraKeys::NAME => Modifier\IgnoreExtraKeys::class,
         Modifier\CaseInsensitive::NAME => Modifier\CaseInsensitive::class
     ];
@@ -24,7 +24,10 @@ final class ModifiersRegistry
         $this->modifiers = self::BUILT_IN_MODIFIERS;
     }
 
-    public function register(string $name, string $class): void
+    /**
+     * @return void
+     */
+    public function register(string $name, string $class)
     {
         if (!\class_exists($class) || \is_a($class, Modifier\MatcherModifier::class, true)) {
             throw new UnknownModifierClassException($name, $class);

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -216,6 +216,45 @@ class LexerTest extends TestCase
     }
 
     /**
+     * @dataProvider validModifiersNamesProvider
+     */
+    public function test_modifiers_names(string $value)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($value);
+        $lexer->moveNext();
+        $this->assertEquals($lexer->lookahead['type'], Lexer::T_MODIFIERS_NAMES);
+        $this->assertEquals($lexer->lookahead['value'], $value);
+    }
+
+    public function validModifiersNamesProvider(): array
+    {
+        return [
+            ['|case_insensitive|'],
+            ['|foo,bar|']
+        ];
+    }
+
+    /**
+     * @dataProvider invalidModifiersNamesProvider
+     */
+    public function test_not_modifiers_names(string $value)
+    {
+        $lexer = new Lexer();
+        $lexer->setInput($value);
+        $lexer->moveNext();
+        $this->assertNotEquals($lexer->lookahead['type'], Lexer::T_MODIFIERS_NAMES);
+    }
+
+    public function invalidModifiersNamesProvider(): array
+    {
+        return [
+            ['||'],
+            ['foo,bar']
+        ];
+    }
+
+    /**
      * @param $lexer
      * @return array
      */

--- a/tests/Matcher/BooleanMatcherTest.php
+++ b/tests/Matcher/BooleanMatcherTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Parser;
 use Coduo\PHPMatcher\Matcher\BooleanMatcher;
+use Coduo\PHPMatcher\Tests\TestParserFactory;
 use PHPUnit\Framework\TestCase;
 
 class BooleanMatcherTest extends TestCase
@@ -18,7 +19,7 @@ class BooleanMatcherTest extends TestCase
 
     public function setUp()
     {
-        $this->matcher = new BooleanMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new BooleanMatcher(TestParserFactory::get());
     }
 
     /**

--- a/tests/Matcher/DoubleMatcherTest.php
+++ b/tests/Matcher/DoubleMatcherTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\DoubleMatcher;
 use Coduo\PHPMatcher\Parser;
+use Coduo\PHPMatcher\Tests\TestParserFactory;
 use PHPUnit\Framework\TestCase;
 
 class DoubleMatcherTest extends TestCase
@@ -18,7 +19,7 @@ class DoubleMatcherTest extends TestCase
 
     public function setUp()
     {
-        $this->matcher = new DoubleMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new DoubleMatcher(TestParserFactory::get());
     }
 
     /**

--- a/tests/Matcher/IntegerMatcherTest.php
+++ b/tests/Matcher/IntegerMatcherTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\IntegerMatcher;
 use Coduo\PHPMatcher\Parser;
+use Coduo\PHPMatcher\Tests\TestParserFactory;
 use PHPUnit\Framework\TestCase;
 
 class IntegerMatcherTest extends TestCase
@@ -18,7 +19,7 @@ class IntegerMatcherTest extends TestCase
 
     public function setUp()
     {
-        $this->matcher = new IntegerMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new IntegerMatcher(TestParserFactory::get());
     }
 
     /**

--- a/tests/Matcher/InterceptingModifiableMatcher.php
+++ b/tests/Matcher/InterceptingModifiableMatcher.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Tests\Matcher;
+
+use Coduo\PHPMatcher\Matcher\ModifiableMatcher;
+use Coduo\PHPMatcher\Matcher\Modifier\MatcherModifier;
+use Coduo\PHPMatcher\Parser\ModifiersRegistry;
+
+final class InterceptingModifiableMatcher extends ModifiableMatcher
+{
+    /** @var MatcherModifier[] */
+    private $applied = [];
+
+    public function supportedModifiers(): array
+    {
+        return \array_keys(ModifiersRegistry::BUILT_IN_MODIFIERS);
+    }
+
+    public function getMatchers(): iterable
+    {
+        return [];
+    }
+
+    public function applyModifier(MatcherModifier $modifier): void
+    {
+        $this->applied[] = $modifier;
+    }
+
+    public function canMatch($pattern): bool
+    {
+        return true;
+    }
+
+    public function appliedModifiers(): array
+    {
+        return $this->applied;
+    }
+}

--- a/tests/Matcher/InterceptingModifiableMatcher.php
+++ b/tests/Matcher/InterceptingModifiableMatcher.php
@@ -17,12 +17,12 @@ final class InterceptingModifiableMatcher extends ModifiableMatcher
         return \array_keys(ModifiersRegistry::BUILT_IN_MODIFIERS);
     }
 
-    public function getMatchers(): iterable
+    public function getMatchers(): array
     {
         return [];
     }
 
-    public function applyModifier(MatcherModifier $modifier): void
+    public function applyModifier(MatcherModifier $modifier)
     {
         $this->applied[] = $modifier;
     }

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Parser;
+use Coduo\PHPMatcher\Tests\TestParserFactory;
 use PHPUnit\Framework\TestCase;
 
 class JsonMatcherTest extends TestCase
@@ -18,7 +19,7 @@ class JsonMatcherTest extends TestCase
 
     public function setUp()
     {
-        $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
+        $parser = TestParserFactory::get();
         $scalarMatchers = new Matcher\ChainMatcher([
             new Matcher\CallbackMatcher(),
             new Matcher\ExpressionMatcher(),
@@ -31,10 +32,13 @@ class JsonMatcherTest extends TestCase
             new Matcher\ScalarMatcher(),
             new Matcher\WildcardMatcher(),
         ]);
-        $this->matcher = new Matcher\JsonMatcher(new Matcher\ChainMatcher([
-            $scalarMatchers,
-            new Matcher\ArrayMatcher($scalarMatchers, $parser)
-        ]));
+        $this->matcher = new Matcher\JsonMatcher(
+            new Matcher\ChainMatcher([
+                $scalarMatchers,
+                new Matcher\ArrayMatcher($scalarMatchers, $parser)
+            ]),
+            $parser
+        );
     }
 
     /**

--- a/tests/Matcher/NullMatcherTest.php
+++ b/tests/Matcher/NullMatcherTest.php
@@ -18,7 +18,7 @@ class NullMatcherTest extends TestCase
 
     public function setUp()
     {
-        $this->matcher = new NullMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new NullMatcher();
     }
 
     /**

--- a/tests/Matcher/NumberMatcherTest.php
+++ b/tests/Matcher/NumberMatcherTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Parser;
 use Coduo\PHPMatcher\Matcher\NumberMatcher;
+use Coduo\PHPMatcher\Tests\TestParserFactory;
 use PHPUnit\Framework\TestCase;
 
 class NumberMatcherTest extends TestCase
@@ -18,7 +19,7 @@ class NumberMatcherTest extends TestCase
 
     public function setUp()
     {
-        $this->matcher = new NumberMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new NumberMatcher(TestParserFactory::get());
     }
 
     /**

--- a/tests/Matcher/ScalarMatcherTest.php
+++ b/tests/Matcher/ScalarMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Matcher\Modifier\CaseInsensitive;
 use Coduo\PHPMatcher\Matcher\ScalarMatcher;
 use PHPUnit\Framework\TestCase;
 
@@ -55,6 +56,34 @@ class ScalarMatcherTest extends TestCase
         $this->assertEquals($error, $matcher->getError());
     }
 
+    /**
+     * @dataProvider positiveCaseInsensitiveMatches
+     */
+    public function test_positive_case_insensitive_matches($value, $pattern)
+    {
+        $matcher = $this->caseInsensitiveMatcher();
+        $this->assertTrue($matcher->match($value, $pattern));
+    }
+
+    /**
+     * @dataProvider negativeCaseInsensitiveMatches
+     */
+    public function test_negative_case_insensitive_matches($value, $pattern)
+    {
+        $matcher = $this->caseInsensitiveMatcher();
+        $this->assertFalse($matcher->match($value, $pattern));
+    }
+
+    /**
+     * @dataProvider negativeCaseInsensitiveMatchDescription
+     */
+    public function test_negative_case_insensitive_match_description($value, $pattern, $error)
+    {
+        $matcher = $this->caseInsensitiveMatcher();
+        $matcher->match($value, $pattern);
+        $this->assertEquals($error, $matcher->getError());
+    }
+
     public static function negativeMatches()
     {
         return [
@@ -102,5 +131,41 @@ class ScalarMatcherTest extends TestCase
             [1.1, false, '"1.1" does not match "false".'],
             [false, ['foo', 'bar'], '"false" does not match "Array(2)".'],
         ];
+    }
+
+    public static function positiveCaseInsensitiveMatches()
+    {
+        return [
+            ['michal', 'Michal'],
+            ['Michal', 'michal'],
+            ['fooBar', 'FOObAR'],
+            ['Bazinga', 'baZIngA']
+        ];
+    }
+
+    public static function negativeCaseInsensitiveMatches()
+    {
+        return [
+            ['michal', 'Michall'],
+            ['fooBar', 'barFoo'],
+            ['Bazinga', 'BaIng']
+        ];
+    }
+
+    public static function negativeCaseInsensitiveMatchDescription()
+    {
+        return [
+            ['michal', 'Michall', '"michal" does not case-insensitive match "Michall".'],
+            ['fooBar', 'barFoo', '"fooBar" does not case-insensitive match "barFoo".'],
+            ['Bazinga', 'BaIng', '"Bazinga" does not case-insensitive match "BaIng".']
+        ];
+    }
+
+    private function caseInsensitiveMatcher(): ScalarMatcher
+    {
+        $matcher = new ScalarMatcher();
+        $matcher->applyModifier(new CaseInsensitive());
+
+        return $matcher;
     }
 }

--- a/tests/Matcher/StringMatcherTest.php
+++ b/tests/Matcher/StringMatcherTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\StringMatcher;
 use Coduo\PHPMatcher\Parser;
+use Coduo\PHPMatcher\Tests\TestParserFactory;
 use PHPUnit\Framework\TestCase;
 
 class StringMatcherTest extends TestCase
@@ -18,7 +19,7 @@ class StringMatcherTest extends TestCase
 
     public function setUp()
     {
-        $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
+        $parser = TestParserFactory::get();
         $this->matcher = new StringMatcher($parser);
     }
     /**

--- a/tests/Matcher/TextMatcherTest.php
+++ b/tests/Matcher/TextMatcherTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Parser;
+use Coduo\PHPMatcher\Tests\TestParserFactory;
 use PHPUnit\Framework\TestCase;
 
 class TextMatcherTest extends TestCase
@@ -18,7 +19,7 @@ class TextMatcherTest extends TestCase
 
     public function setUp()
     {
-        $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
+        $parser = TestParserFactory::get();
         $scalarMatchers = new Matcher\ChainMatcher([
             new Matcher\CallbackMatcher(),
             new Matcher\ExpressionMatcher(),

--- a/tests/Matcher/UuidMatcherTest.php
+++ b/tests/Matcher/UuidMatcherTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Parser;
 use Coduo\PHPMatcher\Matcher\UuidMatcher;
+use Coduo\PHPMatcher\Tests\TestParserFactory;
 use PHPUnit\Framework\TestCase;
 
 class UuidMatcherTest extends TestCase
@@ -18,7 +19,7 @@ class UuidMatcherTest extends TestCase
 
     public function setUp()
     {
-        $this->matcher = new UuidMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new UuidMatcher(TestParserFactory::get());
     }
     /**
      * @dataProvider positiveCanMatchData

--- a/tests/Matcher/XmlMatcherTest.php
+++ b/tests/Matcher/XmlMatcherTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\Matcher;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Parser;
+use Coduo\PHPMatcher\Tests\TestParserFactory;
 use PHPUnit\Framework\TestCase;
 
 class XmlMatcherTest extends TestCase
@@ -18,7 +19,7 @@ class XmlMatcherTest extends TestCase
 
     public function setUp()
     {
-        $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
+        $parser = TestParserFactory::get();
         $scalarMatchers = new Matcher\ChainMatcher([
             new Matcher\CallbackMatcher(),
             new Matcher\ExpressionMatcher(),

--- a/tests/ParserSyntaxErrorTest.php
+++ b/tests/ParserSyntaxErrorTest.php
@@ -17,7 +17,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function setUp()
     {
-        $this->parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
+        $this->parser = new Parser(new Lexer(), new Parser\ExpanderInitializer(), new Parser\ModifiersRegistry());
     }
 
     /**

--- a/tests/TestParserFactory.php
+++ b/tests/TestParserFactory.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Tests;
+
+use Coduo\PHPMatcher\Lexer;
+use Coduo\PHPMatcher\Parser;
+
+final class TestParserFactory
+{
+    public static function get(): Parser
+    {
+        return new Parser(new Lexer(), new Parser\ExpanderInitializer(), new Parser\ModifiersRegistry());
+    }
+}


### PR DESCRIPTION
Introduces idea described [here](https://github.com/coduo/php-matcher/pull/40) with two modifiers: `CaseInsensitive` and `IgnoreExtraKeys`.

#126 is included in this PR, I will rebase after it is merged.