### PR TITLE
Array universal key

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,64 @@ $matcher->match(
 );
 ```
 
+### Json matching with unbounded arrays and objects
+
+```php
+<?php
+
+use Coduo\PHPMatcher\Factory\SimpleFactory;
+
+$factory = new SimpleFactory();
+$matcher = $factory->createMatcher();
+
+$matcher->match(
+  '{
+    "users":[
+      {
+        "firstName": "Norbert",
+        "lastName": "Orzechowicz",
+        "created": "2014-01-01",
+        "roles":["ROLE_USER", "ROLE_DEVELOPER"]},
+        "attributes": {
+          "isAdmin": false,
+          "dateOfBirth" null,
+          "hasEmailVerified": true
+        }
+      },
+      {
+        "firstName": "Michał",
+        "lastName": "Dąbrowski",
+        "created": "2014-01-01",
+        "roles":["ROLE_USER", "ROLE_DEVELOPER", "ROLE_ADMIN"]},
+        "attributes": {
+          "isAdmin": true,
+          "dateOfBirth" null,
+          "hasEmailVerified": true
+        }
+      }
+    ]
+  }',
+  '{
+    "users":[
+      {
+        "firstName": @string@,
+        "lastName": @string@,
+        "created": "@string@.isDateTime()",
+        "roles": [
+            "ROLE_USER",
+            @...@
+        ],
+        "attributes": {
+          "isAdmin": @boolean@,
+          "@*@": "@*@"
+        }
+      }
+    ],
+    @...@
+  }'
+);
+```
+
 ### Xml matching
 
 ```php

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -32,7 +32,7 @@ final class Lexer extends AbstractLexer
             '\\-?[0-9]*\\.?[0-9]*', // numbers
             "'(?:[^']|'')*'", // string between ' character
             '"(?:[^"]|"")*"', // string between " character,
-            '@[a-zA-Z0-9\\*]+@', // type pattern
+            '@[a-zA-Z0-9\\*.]+@', // type pattern
         ];
     }
 

--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -130,7 +130,6 @@ final class ArrayMatcher extends Matcher
 
             $notExistingKeys = $this->findNotExistingKeys($pattern, $values);
             if (\count($notExistingKeys) > 0) {
-                dump($notExistingKeys);
                 $keyNames = \array_keys($notExistingKeys);
                 $path = $this->formatFullPath($parentPath, $this->formatAccessPath($keyNames[0]));
                 $this->setMissingElementInError('value', $path);

--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -201,7 +201,8 @@ final class ArrayMatcher extends Matcher
 
     private function arrayPropertyExists(string $property, array $objectOrArray) : bool
     {
-        return ($objectOrArray instanceof \ArrayAccess || \is_array($objectOrArray)) && isset($objectOrArray[$property]);
+        return ($objectOrArray instanceof \ArrayAccess && isset($objectOrArray[$property])) ||
+            (\is_array($objectOrArray) && \array_key_exists($property, $objectOrArray));
     }
 
     private function getValueByPath(array $array, string $path)

--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -224,7 +224,6 @@ final class ArrayMatcher extends Matcher
 
     private function setMissingElementInError(string $place, string $path)
     {
-        throw new \Exception(\sprintf('There is no element under path %s in %s.', $path, $place));
         $this->error = \sprintf('There is no element under path %s in %s.', $path, $place);
     }
 

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -181,6 +181,7 @@ class LexerTest extends TestCase
             ['@integer@'],
             ['@number@'],
             ['@*@'],
+            ['@...@'],
             ['@wildcard@']
         ];
     }

--- a/tests/Matcher/ArrayMatcherTest.php
+++ b/tests/Matcher/ArrayMatcherTest.php
@@ -158,9 +158,39 @@ class ArrayMatcherTest extends TestCase
             6.66
         ];
 
+        $simpleArrPatternWithUniversalKey = [
+            'users' => [
+                [
+                    'firstName' => '@string@',
+                    Matcher\ArrayMatcher::UNIVERSAL_KEY => '@*@'
+                ],
+                Matcher\ArrayMatcher::UNBOUNDED_PATTERN
+            ],
+            true,
+            false,
+            1,
+            6.66
+        ];
+
+        $simpleArrPatternWithUniversalKeyAndStringValue = [
+            'users' => [
+                [
+                    'firstName' => '@string@',
+                    Matcher\ArrayMatcher::UNIVERSAL_KEY => '@string@'
+                ],
+                Matcher\ArrayMatcher::UNBOUNDED_PATTERN
+            ],
+            true,
+            false,
+            1,
+            6.66
+        ];
+
         return [
             [$simpleArr, $simpleArr],
             [$simpleArr, $simpleArrPattern],
+            [$simpleArr, $simpleArrPatternWithUniversalKey],
+            [$simpleArr, $simpleArrPatternWithUniversalKeyAndStringValue],
             [[], []],
             [['foo' => null], ['foo' => null]],
             [['foo' => null], ['foo' => '@null@']],
@@ -224,8 +254,23 @@ class ArrayMatcherTest extends TestCase
             6.66
         ];
 
+        $simpleArrPatternWithUniversalKeyAndIntegerValue = [
+            'users' => [
+                [
+                    'firstName' => '@string@',
+                    Matcher\ArrayMatcher::UNIVERSAL_KEY => '@integer@'
+                ],
+                Matcher\ArrayMatcher::UNBOUNDED_PATTERN
+            ],
+            true,
+            false,
+            1,
+            6.66
+        ];
+
         return [
             [$simpleArr, $simpleDiff],
+            [$simpleArr, $simpleArrPatternWithUniversalKeyAndIntegerValue],
             [['status' => 'ok', 'data' => [['foo']]], ['status' => 'ok', 'data' => []]],
             [[1], []],
             [['key' => 'val'], ['key' => 'val2']],

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -189,14 +189,6 @@ class JsonMatcherTest extends TestCase
                 '{"username":null, "some_data": @string@}'
             ],
             [
-                '{"username":null,"some_data":"test"}',
-                '{"username":null, "some_data": "@string@"}'
-            ],
-            [
-                '{"username":null,"some_data":"test"}',
-                '{"username":null,"some_data":@string@}'
-            ],
-            [
                 '{"null":null}',
                 '{"null":null}'
             ],

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -189,6 +189,14 @@ class JsonMatcherTest extends TestCase
                 '{"username":null, "some_data": @string@}'
             ],
             [
+                '{"username":null,"some_data":"test"}',
+                '{"username":null, "some_data": "@string@"}'
+            ],
+            [
+                '{"username":null,"some_data":"test"}',
+                '{"username":null,"some_data":@string@}'
+            ],
+            [
                 '{"null":null}',
                 '{"null":null}'
             ],

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -201,6 +201,10 @@ class JsonMatcherTest extends TestCase
                 '{"users":[{"firstName":"Norbert","lastName":"Orzechowicz","roles":"@wildcard@"}]}'
             ],
             [
+                '{"users":[{"firstName":"Norbert","lastName":"Orzechowicz","roles":["ROLE_USER", "ROLE_DEVELOPER"]}]}',
+                '{"users":[{"firstName":"Norbert","@*@":"@*@"}]}'
+            ],
+            [
                 '[{"name": "Norbert"},{"name":"Michał"},{"name":"Bob"},{"name":"Martin"}]',
                 '[{"name": "Norbert"},@...@]'
             ]

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -205,8 +205,16 @@ class JsonMatcherTest extends TestCase
                 '{"users":[{"firstName":"Norbert","@*@":"@*@"}]}'
             ],
             [
+                '{"users":[{"firstName":"Norbert","lastName":"Orzechowicz","roles":["ROLE_USER", "ROLE_DEVELOPER"]},{}]}',
+                '{"users":[{"firstName":"Norbert","@*@":"@*@"},@...@]}'
+            ],
+            [
                 '[{"name": "Norbert"},{"name":"Michał"},{"name":"Bob"},{"name":"Martin"}]',
                 '[{"name": "Norbert"},@...@]'
+            ],
+            [
+                '[{"name": "Norbert","lastName":"Orzechowicz"},{"name":"Michał"},{"name":"Bob"},{"name":"Martin"}]',
+                '[{"name": "Norbert","@*@":"@*@"},@...@]'
             ]
         ];
     }


### PR DESCRIPTION
Array universal key `@*@` will match any key not presented in the pattern.
It works similarly to `@...@` but for key-value arrays.

It needs `"@*@": "@*@"` instead of just `@*@` or `@...@` to bypass JSON validation.

It solves problem described in #40 but it is more elastic than #39 and #132 as it allows both specifying value pattern (like `"@*@": @string@`) and place where additional keys are allowed. Also it is more obvious to guess what wildcard key does than learning about pattern modifiers.