### PR TITLE
PHPUnit 8 compatibility

### DIFF
--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -16,7 +16,9 @@ final class PHPMatcherConstraint extends Constraint
 
     public function __construct(string $pattern)
     {
-        parent::__construct();
+        if (\method_exists(Constraint::class, '__construct')) {
+            parent::__construct();
+        }
 
         $this->pattern = $pattern;
         $this->matcher = $this->createMatcher();


### PR DESCRIPTION
Fix `Error: Cannot call constructor` while using PHPUnit 8.

Constructor of `PHPUnit\Framework\Constraint\Constraint` was removed in PHPUnit 8 (https://github.com/sebastianbergmann/phpunit/issues/3060).