### PR TITLE
Enhance PHPUnit setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,8 +6,6 @@
     <testsuites>
         <testsuite name="PHP Matcher Test Suite">
             <directory>./tests/</directory>
-            <exclude>tests/PHPUnit/PHPMatcherAssertionsTest.php</exclude>
-            <file phpVersion="7.0.0" phpVersionOperator=">=">tests/PHPUnit/PHPMatcherAssertionsTest.php</file>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
# Changed log
- Remove `sudo: false` setting because the root privilege is disabled by default.
The reference is [here](https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure).
- Remove the excluded files because the PHP will always be greater than `7.0` version now.