### PR TITLE
Require stable version of openlss/lib-array2xml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/property-access": "^2.3|^3.0|^4.0",
         "symfony/expression-language": "^2.3|^3.0|^4.0",
         "doctrine/lexer": "1.0.*",
-        "openlss/lib-array2xml": "~0.0.9"
+        "openlss/lib-array2xml": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",


### PR DESCRIPTION
version 1 has been released:
https://github.com/nullivex/lib-array2xml/releases

This also allows php-matcher to be installed along side psalm:
https://github.com/vimeo/psalm/pull/1745