### PR TITLE
Add PhpUnit rich diff for JSON string comparison

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": ">=7.0.0",
         "ext-filter": "*",
+        "ext-json": "*",
         "coduo/php-to-string": "^2",
         "symfony/property-access": "^2.3|^3.0|^4.0",
         "symfony/expression-language": "^2.3|^3.0|^4.0",


### PR DESCRIPTION
This would help debugging:

```
❯ bin/phpunit --testdox --filter testmytest
PHPUnit 7.5.14 by Sebastian Bergmann and contributors.

Coduo\PHPMatcher\Tests\PHPUnit\PHPMatcherAssertions
 ✘ Mytest
   │
   │ Failed asserting that '{"foo":"bar"}' matches the pattern.
   │ "bar" does not match "@integer@".
   │ --- Expected
   │ +++ Actual
   │ @@ @@
   │  {
   │ -    "foo": "@integer@"
   │ +    "foo": "bar"
   │  }
```

The code was taken from PhpUnit JSON string asserts with few changes.