### PR TITLE
Do not return any error when matching was successful

### DIFF
--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -17,7 +17,13 @@ final class Matcher
 
     public function match($value, $pattern) : bool
     {
-        return $this->matcher->match($value, $pattern);
+        $result = $this->matcher->match($value, $pattern);
+
+        if ($result === true) {
+            $this->matcher->clearError();
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Matcher/Matcher.php
+++ b/src/Matcher/Matcher.php
@@ -28,7 +28,7 @@ abstract class Matcher implements ValueMatcher
         return false;
     }
 
-    public function clearError() : void
+    public function clearError()
     {
         $this->error = null;
     }

--- a/src/Matcher/Matcher.php
+++ b/src/Matcher/Matcher.php
@@ -27,4 +27,9 @@ abstract class Matcher implements ValueMatcher
 
         return false;
     }
+
+    public function clearError() : void
+    {
+        $this->error = null;
+    }
 }

--- a/src/Matcher/ValueMatcher.php
+++ b/src/Matcher/ValueMatcher.php
@@ -22,4 +22,9 @@ interface ValueMatcher
      * @return null|string
      */
     public function getError();
+
+    /**
+     * Clear last error
+     */
+    public function clearError() : void;
 }

--- a/src/Matcher/ValueMatcher.php
+++ b/src/Matcher/ValueMatcher.php
@@ -26,5 +26,5 @@ interface ValueMatcher
     /**
      * Clear last error
      */
-    public function clearError() : void;
+    public function clearError();
 }

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Factory\SimpleFactory;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Parser;
@@ -124,6 +125,15 @@ class JsonMatcherTest extends TestCase
         $this->assertFalse($this->matcher->match($value, $pattern));
 
         $this->assertEquals($this->matcher->getError(), 'Invalid given JSON of pattern. Syntax error, malformed JSON');
+    }
+
+    /**
+     * Solves https://github.com/coduo/php-matcher/issues/156
+     */
+    public function test_empty_error_after_successful_match()
+    {
+        $this->assertTrue($this->matcher->match($value = '{"foo": "bar"}', $pattern = '{"foo": "@string@"}'));
+        $this->assertNull($this->matcher->getError());
     }
 
     public function test_error_when_json_value_is_invalid()

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Parser;

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -62,7 +62,7 @@ class MatcherTest extends TestCase
             'data' => '@wildcard@',
         ];
 
-        $this->assertTrue($this->matcher->match($value, $expectation), $this->matcher->getError());
+        $this->assertTrue($this->matcher->match($value, $expectation), (string) $this->matcher->getError());
         $this->assertTrue(PHPMatcher::match($value, $expectation, $error), (string) $error);
     }
 


### PR DESCRIPTION
This should fix https://github.com/coduo/php-matcher/issues/156 I wasn't sure what was wrong there but @teklakct pointed out that matcher is returning error even if matching was successful. 
If we think about how matcher works internally it kind of make sense but it's definitely not expected behavior. This PR should fix it. 