### PR TITLE
 Do not use anymore child matcher errors in Json/XML matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ if (!PHPMatcher::match("lorem ipsum dolor", "@string@", $error)) {
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $match = $matcher->match("lorem ipsum dolor", "@string@");
@@ -98,9 +98,9 @@ $matcher->getError(); // returns null or error message
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(1, 1);
@@ -112,9 +112,9 @@ $matcher->match('string', 'string');
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match('Norbert', '@string@');
@@ -127,9 +127,9 @@ $matcher->match("lorem ipsum dolor", "@string@.startsWith('lorem').contains('ips
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match('2014-08-19', '@string@.isDateTime()');
@@ -143,9 +143,9 @@ $matcher->match('2014-08-19', '@string@.isDateTime().before("today").after("+ 10
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(100, '@integer@');
@@ -158,9 +158,9 @@ $matcher->match(100, '@integer@.lowerThan(200).greaterThan(10)');
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(100, '@number@');
@@ -175,9 +175,9 @@ $matcher->match(0b10100111001, '@number@');
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(10.1, "@double@");
@@ -189,9 +189,9 @@ $matcher->match(10.1, "@double@.lowerThan(50.12).greaterThan(10)");
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(true, "@boolean@");
@@ -203,9 +203,9 @@ $matcher->match(false, "@boolean@");
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match("@integer@", "@*@");
@@ -221,9 +221,9 @@ $matcher->match(new \stdClass, "@wildcard@");
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(new \DateTime('2014-04-01'), "expr(value.format('Y-m-d') == '2014-04-01'");
@@ -235,9 +235,9 @@ $matcher->match("Norbert", "expr(value === 'Norbert')");
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match('9f4db639-0e87-4367-9beb-d64e3f42ae18', '@uuid@');
@@ -248,9 +248,9 @@ $matcher->match('9f4db639-0e87-4367-9beb-d64e3f42ae18', '@uuid@');
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(
@@ -307,9 +307,9 @@ $matcher->match(
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(
@@ -341,9 +341,9 @@ $matcher->match(
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(
@@ -399,9 +399,9 @@ $matcher->match(
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
-$factory = new SimpleFactory();
+$factory = new MatcherFactory();
 $matcher = $factory->createMatcher();
 
 $matcher->match(<<<XML

--- a/src/Factory/MatcherFactory.php
+++ b/src/Factory/MatcherFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Factory;
+
+use Coduo\PHPMatcher\Factory;
+use Coduo\PHPMatcher\Lexer;
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Parser;
+
+final class MatcherFactory implements Factory
+{
+    public function createMatcher() : Matcher
+    {
+        return new Matcher($this->buildMatchers($this->buildParser()));
+    }
+
+    protected function buildMatchers(Parser $parser) : Matcher\ChainMatcher
+    {
+        $scalarMatchers = $this->buildScalarMatchers($parser);
+        $arrayMatcher = $this->buildArrayMatcher($scalarMatchers, $parser);
+
+        $chainMatcher = new Matcher\ChainMatcher([
+            $scalarMatchers,
+            $arrayMatcher,
+            new Matcher\OrMatcher($scalarMatchers),
+            new Matcher\JsonMatcher($arrayMatcher),
+            new Matcher\XmlMatcher($arrayMatcher),
+            new Matcher\TextMatcher($scalarMatchers, $parser)
+        ]);
+
+        return $chainMatcher;
+    }
+
+    protected function buildArrayMatcher(Matcher\ChainMatcher $scalarMatchers, Parser $parser) : Matcher\ArrayMatcher
+    {
+        $orMatcher = new Matcher\OrMatcher($scalarMatchers);
+        $arrayMatcher = new Matcher\ArrayMatcher(
+            new Matcher\ChainMatcher([
+                $orMatcher,
+                $scalarMatchers,
+                new Matcher\TextMatcher($scalarMatchers, $parser)
+            ]),
+            $parser
+        );
+
+        return $arrayMatcher;
+    }
+
+    protected function buildScalarMatchers(Parser $parser) : Matcher\ChainMatcher
+    {
+        return new Matcher\ChainMatcher([
+            new Matcher\CallbackMatcher(),
+            new Matcher\ExpressionMatcher(),
+            new Matcher\NullMatcher(),
+            new Matcher\StringMatcher($parser),
+            new Matcher\IntegerMatcher($parser),
+            new Matcher\BooleanMatcher($parser),
+            new Matcher\DoubleMatcher($parser),
+            new Matcher\NumberMatcher($parser),
+            new Matcher\ScalarMatcher(),
+            new Matcher\WildcardMatcher(),
+            new Matcher\UuidMatcher($parser),
+            new Matcher\JsonObjectMatcher($parser)
+        ]);
+    }
+
+    protected function buildParser() : Parser
+    {
+        return new Parser(new Lexer(), new Parser\ExpanderInitializer());
+    }
+}

--- a/src/Factory/SimpleFactory.php
+++ b/src/Factory/SimpleFactory.php
@@ -5,69 +5,15 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Factory;
 
 use Coduo\PHPMatcher\Factory;
-use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
-use Coduo\PHPMatcher\Parser;
 
+/**
+ * @deprecated Please use \Coduo\PHPMatcher\Factory\MatcherFactory instead
+ */
 class SimpleFactory implements Factory
 {
     public function createMatcher() : Matcher
     {
-        return new Matcher($this->buildMatchers($this->buildParser()));
-    }
-
-    protected function buildMatchers(Parser $parser) : Matcher\ChainMatcher
-    {
-        $scalarMatchers = $this->buildScalarMatchers($parser);
-        $arrayMatcher = $this->buildArrayMatcher($scalarMatchers, $parser);
-
-        $chainMatcher = new Matcher\ChainMatcher([
-            $scalarMatchers,
-            $arrayMatcher,
-            new Matcher\OrMatcher($scalarMatchers),
-            new Matcher\JsonMatcher($arrayMatcher),
-            new Matcher\XmlMatcher($arrayMatcher),
-            new Matcher\TextMatcher($scalarMatchers, $parser)
-        ]);
-
-        return $chainMatcher;
-    }
-
-    protected function buildArrayMatcher(Matcher\ChainMatcher $scalarMatchers, Parser $parser) : Matcher\ArrayMatcher
-    {
-        $orMatcher = new Matcher\OrMatcher($scalarMatchers);
-        $arrayMatcher = new Matcher\ArrayMatcher(
-            new Matcher\ChainMatcher([
-                $orMatcher,
-                $scalarMatchers,
-                new Matcher\TextMatcher($scalarMatchers, $parser)
-            ]),
-            $parser
-        );
-
-        return $arrayMatcher;
-    }
-
-    protected function buildScalarMatchers(Parser $parser) : Matcher\ChainMatcher
-    {
-        return new Matcher\ChainMatcher([
-            new Matcher\CallbackMatcher(),
-            new Matcher\ExpressionMatcher(),
-            new Matcher\NullMatcher(),
-            new Matcher\StringMatcher($parser),
-            new Matcher\IntegerMatcher($parser),
-            new Matcher\BooleanMatcher($parser),
-            new Matcher\DoubleMatcher($parser),
-            new Matcher\NumberMatcher($parser),
-            new Matcher\ScalarMatcher(),
-            new Matcher\WildcardMatcher(),
-            new Matcher\UuidMatcher($parser),
-            new Matcher\JsonObjectMatcher($parser)
-        ]);
-    }
-
-    protected function buildParser() : Parser
-    {
-        return new Parser(new Lexer(), new Parser\ExpanderInitializer());
+        return (new MatcherFactory())->createMatcher();
     }
 }

--- a/src/Factory/SimpleFactory.php
+++ b/src/Factory/SimpleFactory.php
@@ -21,20 +21,21 @@ class SimpleFactory implements Factory
     protected function buildMatchers() : Matcher\ChainMatcher
     {
         $scalarMatchers = $this->buildScalarMatchers();
-        $orMatcher = $this->buildOrMatcher();
+        $arrayMatcher = $this->buildArrayMatcher();
 
         $chainMatcher = new Matcher\ChainMatcher([
             $scalarMatchers,
-            $orMatcher,
-            new Matcher\JsonMatcher($orMatcher, $this->buildParser()),
-            new Matcher\XmlMatcher($orMatcher),
+            $arrayMatcher,
+            new Matcher\OrMatcher($scalarMatchers),
+            new Matcher\JsonMatcher($arrayMatcher),
+            new Matcher\XmlMatcher($arrayMatcher),
             new Matcher\TextMatcher($scalarMatchers, $this->buildParser())
         ]);
 
         return $chainMatcher;
     }
 
-    protected function buildOrMatcher() : Matcher\ChainMatcher
+    protected function buildArrayMatcher() : Matcher\ArrayMatcher
     {
         $scalarMatchers = $this->buildScalarMatchers();
         $orMatcher = new Matcher\OrMatcher($scalarMatchers);
@@ -47,12 +48,8 @@ class SimpleFactory implements Factory
             $this->buildParser()
         );
 
-        $chainMatcher = new Matcher\ChainMatcher([
-            $orMatcher,
-            $arrayMatcher,
-        ]);
 
-        return $chainMatcher;
+        return $arrayMatcher;
     }
 
     /**

--- a/src/Matcher/JsonMatcher.php
+++ b/src/Matcher/JsonMatcher.php
@@ -8,11 +8,11 @@ use Coduo\PHPMatcher\Matcher\Pattern\Assert\Json;
 
 final class JsonMatcher extends Matcher
 {
-    private $matcher;
+    private $arrayMatcher;
 
-    public function __construct(ValueMatcher $matcher)
+    public function __construct(ArrayMatcher $arrayMatcher)
     {
-        $this->matcher = $matcher;
+        $this->arrayMatcher = $arrayMatcher;
     }
 
     public function match($value, $pattern) : bool
@@ -22,19 +22,22 @@ final class JsonMatcher extends Matcher
         }
 
         if (!Json::isValid($value)) {
-            $this->error = \sprintf('Invalid given JSON of value. %s', $this->getErrorMessage());
+            $this->error = \sprintf('Invalid given JSON of value. %s', Json::getErrorMessage());
             return false;
         }
 
         if (!Json::isValidPattern($pattern)) {
-            $this->error = \sprintf('Invalid given JSON of pattern. %s', $this->getErrorMessage());
+            $this->error = \sprintf('Invalid given JSON of pattern. %s', Json::getErrorMessage());
             return false;
         }
 
         $transformedPattern = Json::transformPattern($pattern);
-        $match = $this->matcher->match(\json_decode($value, true), \json_decode($transformedPattern, true));
+
+        $match = $this->arrayMatcher->match(\json_decode($value, true), \json_decode($transformedPattern, true));
+
         if (!$match) {
-            $this->error = $this->matcher->getError();
+            $this->error = $this->arrayMatcher->getError();
+
             return false;
         }
 
@@ -44,23 +47,5 @@ final class JsonMatcher extends Matcher
     public function canMatch($pattern) : bool
     {
         return Json::isValidPattern($pattern);
-    }
-
-    private function getErrorMessage()
-    {
-        switch (\json_last_error()) {
-            case JSON_ERROR_DEPTH:
-                return 'Maximum stack depth exceeded';
-            case JSON_ERROR_STATE_MISMATCH:
-                return 'Underflow or the modes mismatch';
-            case JSON_ERROR_CTRL_CHAR:
-                return 'Unexpected control character found';
-            case JSON_ERROR_SYNTAX:
-                return 'Syntax error, malformed JSON';
-            case JSON_ERROR_UTF8:
-                return 'Malformed UTF-8 characters, possibly incorrectly encoded';
-            default:
-                return 'Unknown error';
-        }
     }
 }

--- a/src/Matcher/JsonMatcher.php
+++ b/src/Matcher/JsonMatcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Matcher;
 
 use Coduo\PHPMatcher\Matcher\Pattern\Assert\Json;
+use Coduo\ToString\StringConverter;
 
 final class JsonMatcher extends Matcher
 {
@@ -36,7 +37,11 @@ final class JsonMatcher extends Matcher
         $match = $this->arrayMatcher->match(\json_decode($value, true), \json_decode($transformedPattern, true));
 
         if (!$match) {
-            $this->error = $this->arrayMatcher->getError();
+            $this->error = \sprintf(
+                'Value %s does not match pattern %s',
+                new StringConverter($value),
+                new StringConverter($pattern)
+            );
 
             return false;
         }

--- a/src/Matcher/JsonObjectMatcher.php
+++ b/src/Matcher/JsonObjectMatcher.php
@@ -25,7 +25,7 @@ final class JsonObjectMatcher extends Matcher
         }
 
         if (!Json::isValid($value) && !\is_null($value) && !\is_array($value)) {
-            $this->error = \sprintf('Invalid given JSON of value. %s', $this->getErrorMessage());
+            $this->error = \sprintf('Invalid given JSON of value. %s', Json::getErrorMessage());
             return false;
         }
 
@@ -60,23 +60,5 @@ final class JsonObjectMatcher extends Matcher
         }
 
         return true;
-    }
-
-    private function getErrorMessage()
-    {
-        switch (\json_last_error()) {
-            case JSON_ERROR_DEPTH:
-                return 'Maximum stack depth exceeded';
-            case JSON_ERROR_STATE_MISMATCH:
-                return 'Underflow or the modes mismatch';
-            case JSON_ERROR_CTRL_CHAR:
-                return 'Unexpected control character found';
-            case JSON_ERROR_SYNTAX:
-                return 'Syntax error, malformed JSON';
-            case JSON_ERROR_UTF8:
-                return 'Malformed UTF-8 characters, possibly incorrectly encoded';
-            default:
-                return 'Unknown error';
-        }
     }
 }

--- a/src/Matcher/Pattern/Assert/Json.php
+++ b/src/Matcher/Pattern/Assert/Json.php
@@ -44,4 +44,22 @@ final class Json
             )
         );
     }
+
+    public static function getErrorMessage()
+    {
+        switch (\json_last_error()) {
+            case JSON_ERROR_DEPTH:
+                return 'Maximum stack depth exceeded';
+            case JSON_ERROR_STATE_MISMATCH:
+                return 'Underflow or the modes mismatch';
+            case JSON_ERROR_CTRL_CHAR:
+                return 'Unexpected control character found';
+            case JSON_ERROR_SYNTAX:
+                return 'Syntax error, malformed JSON';
+            case JSON_ERROR_UTF8:
+                return 'Malformed UTF-8 characters, possibly incorrectly encoded';
+            default:
+                return 'Unknown error';
+        }
+    }
 }

--- a/src/Matcher/Pattern/Expander/Repeat.php
+++ b/src/Matcher/Pattern/Expander/Repeat.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
 use Coduo\ToString\StringConverter;
@@ -55,7 +55,7 @@ final class Repeat implements PatternExpander
             return false;
         }
 
-        $factory = new SimpleFactory();
+        $factory = new MatcherFactory();
         $matcher = $factory->createMatcher();
 
         if ($this->isScalar) {

--- a/src/Matcher/XmlMatcher.php
+++ b/src/Matcher/XmlMatcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Matcher;
 
 use Coduo\PHPMatcher\Matcher\Pattern\Assert\Xml;
+use Coduo\ToString\StringConverter;
 use LSS\XML2Array;
 
 final class XmlMatcher extends Matcher
@@ -31,7 +32,12 @@ final class XmlMatcher extends Matcher
 
         $match = $this->arrayMatcher->match($arrayValue, $arrayPattern);
         if (!$match) {
-            $this->error = $this->arrayMatcher->getError();
+            $this->error = \sprintf(
+                'Value %s does not match pattern %s',
+                new StringConverter($value),
+                new StringConverter($pattern)
+            );
+
             return false;
         }
 

--- a/src/Matcher/XmlMatcher.php
+++ b/src/Matcher/XmlMatcher.php
@@ -9,11 +9,11 @@ use LSS\XML2Array;
 
 final class XmlMatcher extends Matcher
 {
-    private $matcher;
+    private $arrayMatcher;
 
-    public function __construct(ValueMatcher $matcher)
+    public function __construct(ArrayMatcher $arrayMatcher)
     {
-        $this->matcher = $matcher;
+        $this->arrayMatcher = $arrayMatcher;
     }
 
     public function match($value, $pattern) : bool
@@ -29,9 +29,9 @@ final class XmlMatcher extends Matcher
         $arrayValue = XML2Array::createArray($value);
         $arrayPattern = XML2Array::createArray($pattern);
 
-        $match = $this->matcher->match($arrayValue, $arrayPattern);
+        $match = $this->arrayMatcher->match($arrayValue, $arrayPattern);
         if (!$match) {
-            $this->error = $this->matcher->getError();
+            $this->error = $this->arrayMatcher->getError();
             return false;
         }
 

--- a/src/PHPMatcher.php
+++ b/src/PHPMatcher.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher;
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 
 final class PHPMatcher
 {
     public static function match($value, $pattern, string &$error = null) : bool
     {
-        $factory = new SimpleFactory();
+        $factory = new MatcherFactory();
         $matcher = $factory->createMatcher();
 
         if (!$matcher->match($value, $pattern)) {

--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\PHPUnit;
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 use Coduo\PHPMatcher\Matcher;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Util\Json;
@@ -54,7 +54,7 @@ final class PHPMatcherConstraint extends Constraint
 
     private function createMatcher() : Matcher
     {
-        $factory = new SimpleFactory();
+        $factory = new MatcherFactory();
 
         return $factory->createMatcher();
     }

--- a/tests/EmptyPatternsTest.php
+++ b/tests/EmptyPatternsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests;
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +18,7 @@ final class EmptyPatternsTest extends TestCase
 
     public function setUp() : void
     {
-        $factory = new SimpleFactory();
+        $factory = new MatcherFactory();
         $this->matcher = $factory->createMatcher();
     }
 

--- a/tests/ExpandersTest.php
+++ b/tests/ExpandersTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests;
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +18,7 @@ final class ExpandersTest extends TestCase
 
     public function setUp() : void
     {
-        $factory = new SimpleFactory();
+        $factory = new MatcherFactory();
         $this->matcher = $factory->createMatcher();
     }
 

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -92,7 +92,7 @@ class JsonMatcherTest extends TestCase
         ]);
 
         $this->assertFalse($this->matcher->match($value, $pattern));
-        $this->assertEquals($this->matcher->getError(), '"Michał" does not match "@boolean@".');
+        $this->assertEquals($this->matcher->getError(), 'Value {"users":[{"name":"Norbert"},{"name":"Micha\u0142"}]} does not match pattern {"users":[{"name":"@string@"},{"name":"@boolean@"}]}');
     }
 
     public function test_error_when_path_in_nested_pattern_does_not_exist()
@@ -102,7 +102,7 @@ class JsonMatcherTest extends TestCase
 
         $this->assertFalse($this->matcher->match($value, $pattern));
 
-        $this->assertEquals($this->matcher->getError(), 'There is no element under path [foo][bar][baz] in pattern.');
+        $this->assertEquals($this->matcher->getError(), 'Value {"foo":{"bar":{"baz":"bar value"}}} does not match pattern {"foo":{"bar":{"faz":"faz value"}}}');
     }
 
     public function test_error_when_path_in_nested_value_does_not_exist()
@@ -112,7 +112,7 @@ class JsonMatcherTest extends TestCase
 
         $this->assertFalse($this->matcher->match($value, $pattern));
 
-        $this->assertEquals($this->matcher->getError(), 'There is no element under path [foo][bar][faz] in value.');
+        $this->assertEquals($this->matcher->getError(), 'Value {"foo":{"bar":[]}} does not match pattern {"foo":{"bar":{"faz":"faz value"}}}');
     }
 
     public function test_error_when_json_pattern_is_invalid()

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -31,10 +31,9 @@ class JsonMatcherTest extends TestCase
             new Matcher\ScalarMatcher(),
             new Matcher\WildcardMatcher(),
         ]);
-        $this->matcher = new Matcher\JsonMatcher(new Matcher\ChainMatcher([
-            $scalarMatchers,
+        $this->matcher = new Matcher\JsonMatcher(
             new Matcher\ArrayMatcher($scalarMatchers, $parser)
-        ]));
+        );
     }
 
     /**

--- a/tests/Matcher/OrMatcherTest.php
+++ b/tests/Matcher/OrMatcherTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 use Coduo\PHPMatcher\Matcher;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +17,7 @@ class OrMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $factory = new SimpleFactory();
+        $factory = new MatcherFactory();
         $this->matcher = $factory->createMatcher();
     }
 

--- a/tests/Matcher/XmlMatcherTest.php
+++ b/tests/Matcher/XmlMatcherTest.php
@@ -33,12 +33,7 @@ class XmlMatcherTest extends TestCase
         ]);
 
         $this->matcher = new Matcher\XmlMatcher(
-            new Matcher\ChainMatcher(
-                [
-                $scalarMatchers,
-                new Matcher\ArrayMatcher($scalarMatchers, $parser)
-                ]
-            )
+            new Matcher\ArrayMatcher($scalarMatchers, $parser)
         );
     }
 

--- a/tests/OrMatcherTest.php
+++ b/tests/OrMatcherTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests;
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Factory\MatcherFactory;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +18,7 @@ final class OrMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $factory = new SimpleFactory();
+        $factory = new MatcherFactory();
         $this->matcher = $factory->createMatcher();
     }
 


### PR DESCRIPTION
This PR goal is to increase verbosity of Json/XML matchers error messages. It also deprecates SimpleFactory in favor of MatcherFactory (simple was terrible name) and simplifies factory building process. 