### PR TITLE
Added match expander that allows to match nullable @json@ objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ $matcher->getError(); // returns null or error message
 * ``@*@`` || ``@wildcard@``
 * ``expr(expression)``
 * ``@uuid@``
+* ``@json@``
 * ``@strig@||@integer@`` - string OR integer
 
 ### Available pattern expanders
@@ -85,11 +86,12 @@ $matcher->getError(); // returns null or error message
 * ``lowerThan($boundry)``
 * ``greaterThan($boundry)``
 * ``inArray($value)``
-* ``oneOf(...$expanders)`` - example usage ``"@string@.oneOf(contains('foo'), contains('bar'), contains('baz'))"``
-* ``matchRegex($regex)`` - example usage ``"@string@.matchRegex('/^lorem.+/')"``
+* ``oneOf(...$expanders)`` - example ``"@string@.oneOf(contains('foo'), contains('bar'), contains('baz'))"``
+* ``matchRegex($regex)`` - example ``"@string@.matchRegex('/^lorem.+/')"``
 * ``optional()`` - work's only with ``ArrayMatcher``, ``JsonMatcher`` and ``XmlMatcher``
-* ``count()`` - work's only with ``ArrayMatcher`` - example usage ``"@array@.count(5)"``
-* ``repeat($pattern, $isStrict = true)`` - example usage ``'@array@.repeat({"name": "foe"})'`` or ``"@array@.repeat('@string@')"``
+* ``count()`` - work's only with ``ArrayMatcher`` - example ``"@array@.count(5)"``
+* ``repeat($pattern, $isStrict = true)`` - example ``'@array@.repeat({"name": "foe"})'`` or ``"@array@.repeat('@string@')"``
+* ``match($pattern)`` - example ``{"image":"@json@.match({\"url\":\"@string@.isUrl()\"})"}``
 
 ## Example usage
 
@@ -358,6 +360,9 @@ $matcher->match(
           "isAdmin": false,
           "dateOfBirth" null,
           "hasEmailVerified": true
+        },
+        "avatar": {
+          "url": "http://avatar-image.com/avatar.png"
         }
       },
       {
@@ -369,7 +374,8 @@ $matcher->match(
           "isAdmin": true,
           "dateOfBirth" null,
           "hasEmailVerified": true
-        }
+        },
+        "avatar": null
       }
     ]
   }',
@@ -386,7 +392,8 @@ $matcher->match(
         "attributes": {
           "isAdmin": @boolean@,
           "@*@": "@*@"
-        }
+        },
+        "avatar": "@json@.match({\"url\":\"@string@.isUrl()\"})"
       }
     ],
     @...@

--- a/src/Matcher/JsonMatcher.php
+++ b/src/Matcher/JsonMatcher.php
@@ -32,7 +32,7 @@ final class JsonMatcher extends Matcher
             return false;
         }
 
-        $transformedPattern = Json::transformPattern($pattern);
+        $transformedPattern = Json::isValid($pattern) ? $pattern : Json::transformPattern($pattern);
 
         $match = $this->arrayMatcher->match(\json_decode($value, true), \json_decode($transformedPattern, true));
 

--- a/src/Matcher/Pattern/Assert/Json.php
+++ b/src/Matcher/Pattern/Assert/Json.php
@@ -29,7 +29,7 @@ final class Json
             return false;
         }
 
-        return self::isValid(self::transformPattern($value));
+        return self::isValid($value) || self::isValid(self::transformPattern($value));
     }
 
     public static function transformPattern(string $pattern) : string

--- a/src/Matcher/Pattern/Expander/After.php
+++ b/src/Matcher/Pattern/Expander/After.php
@@ -67,7 +67,7 @@ final class After implements PatternExpander
         }
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/Before.php
+++ b/src/Matcher/Pattern/Expander/Before.php
@@ -66,7 +66,7 @@ final class Before implements PatternExpander
         }
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/Contains.php
+++ b/src/Matcher/Pattern/Expander/Contains.php
@@ -47,7 +47,7 @@ final class Contains implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/Count.php
+++ b/src/Matcher/Pattern/Expander/Count.php
@@ -39,7 +39,7 @@ final class Count implements PatternExpander
 
         return true;
     }
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/EndsWith.php
+++ b/src/Matcher/Pattern/Expander/EndsWith.php
@@ -51,7 +51,7 @@ final class EndsWith implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/GreaterThan.php
+++ b/src/Matcher/Pattern/Expander/GreaterThan.php
@@ -44,7 +44,7 @@ final class GreaterThan implements PatternExpander
         return $value > $this->boundary;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/InArray.php
+++ b/src/Matcher/Pattern/Expander/InArray.php
@@ -40,7 +40,7 @@ final class InArray implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/IsDateTime.php
+++ b/src/Matcher/Pattern/Expander/IsDateTime.php
@@ -33,7 +33,7 @@ final class IsDateTime implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/IsEmail.php
+++ b/src/Matcher/Pattern/Expander/IsEmail.php
@@ -33,7 +33,7 @@ final class IsEmail implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/IsEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsEmpty.php
@@ -29,7 +29,7 @@ final class IsEmpty implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/IsIp.php
+++ b/src/Matcher/Pattern/Expander/IsIp.php
@@ -33,7 +33,7 @@ final class IsIp implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/IsNotEmpty.php
+++ b/src/Matcher/Pattern/Expander/IsNotEmpty.php
@@ -28,7 +28,7 @@ final class IsNotEmpty implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/IsUrl.php
+++ b/src/Matcher/Pattern/Expander/IsUrl.php
@@ -33,7 +33,7 @@ final class IsUrl implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/LowerThan.php
+++ b/src/Matcher/Pattern/Expander/LowerThan.php
@@ -45,7 +45,7 @@ final class LowerThan implements PatternExpander
         return $value < $this->boundary;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/Match.php
+++ b/src/Matcher/Pattern/Expander/Match.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\Matcher;
+
+final class Match implements Matcher\Pattern\PatternExpander
+{
+    const NAME = 'match';
+
+    /**
+     * @var Matcher
+     */
+    private $matcher;
+    private $pattern;
+
+    public function __construct($pattern)
+    {
+        $this->pattern = $pattern;
+    }
+
+    public static function is(string $name) : bool
+    {
+        return self::NAME === $name;
+    }
+
+    public function match($value) : bool
+    {
+        if (\is_null($this->matcher)) {
+            $this->matcher = (new MatcherFactory())->createMatcher();
+        }
+
+        return $this->matcher->match($value, $this->pattern);
+    }
+
+    public function getError() : ?string
+    {
+        return $this->matcher->getError();
+    }
+}

--- a/src/Matcher/Pattern/Expander/MatchRegex.php
+++ b/src/Matcher/Pattern/Expander/MatchRegex.php
@@ -50,7 +50,7 @@ final class MatchRegex implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/NotContains.php
+++ b/src/Matcher/Pattern/Expander/NotContains.php
@@ -48,7 +48,7 @@ final class NotContains implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/OneOf.php
+++ b/src/Matcher/Pattern/Expander/OneOf.php
@@ -49,7 +49,7 @@ final class OneOf implements PatternExpander
         return false;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/Optional.php
+++ b/src/Matcher/Pattern/Expander/Optional.php
@@ -20,7 +20,7 @@ final class Optional implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return null;
     }

--- a/src/Matcher/Pattern/Expander/Repeat.php
+++ b/src/Matcher/Pattern/Expander/Repeat.php
@@ -65,7 +65,7 @@ final class Repeat implements PatternExpander
         return $this->matchJson($values, $matcher);
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/Expander/StartsWith.php
+++ b/src/Matcher/Pattern/Expander/StartsWith.php
@@ -52,7 +52,7 @@ final class StartsWith implements PatternExpander
         return true;
     }
 
-    public function getError()
+    public function getError() : ?string
     {
         return $this->error;
     }

--- a/src/Matcher/Pattern/PatternExpander.php
+++ b/src/Matcher/Pattern/PatternExpander.php
@@ -10,5 +10,5 @@ interface PatternExpander
 
     public function match($value) : bool;
 
-    public function getError();
+    public function getError() : ?string;
 }

--- a/src/Parser/ExpanderInitializer.php
+++ b/src/Parser/ExpanderInitializer.php
@@ -34,6 +34,7 @@ final class ExpanderInitializer
         Expander\Optional::NAME => Expander\Optional::class,
         Expander\StartsWith::NAME => Expander\StartsWith::class,
         Expander\Repeat::NAME => Expander\Repeat::class,
+        Expander\Match::NAME => Expander\Match::class
     ];
 
     public function setExpanderDefinition(string $expanderName, string $expanderFQCN)

--- a/tests/ExpandersTest.php
+++ b/tests/ExpandersTest.php
@@ -27,7 +27,7 @@ final class ExpandersTest extends TestCase
      */
     public function test_expanders($value, $pattern, $expectedResult)
     {
-        $this->assertSame($expectedResult, $this->matcher->match($value, $pattern));
+        $this->assertSame($expectedResult, $this->matcher->match($value, $pattern), (string) $this->matcher->getError());
         $this->assertSame($expectedResult, PHPMatcher::match($value, $pattern));
     }
 
@@ -77,6 +77,7 @@ final class ExpandersTest extends TestCase
             ['2001:0db8:0000:42a1:0000:0000:ab1c:0001', '@string@.isIp()', true],
             ['127.255.999.999', '@string@.isIp()', false],
             ['foo:bar:42:42', '@string@.isIp()', false],
+            ['{"image":{"url":"http://image.com"}}', '{"image":"@json@.match({\"url\":\"@string@.isUrl()\"})"}', true],
         ];
     }
 }

--- a/tests/ExpandersTest.php
+++ b/tests/ExpandersTest.php
@@ -78,6 +78,7 @@ final class ExpandersTest extends TestCase
             ['127.255.999.999', '@string@.isIp()', false],
             ['foo:bar:42:42', '@string@.isIp()', false],
             ['{"image":{"url":"http://image.com"}}', '{"image":"@json@.match({\"url\":\"@string@.isUrl()\"})"}', true],
+            ['{"image":{"url":null}}', '{"image":"@null@||@json@.match({\"url\":\"@string@.isUrl()\"})"}', true],
         ];
     }
 }

--- a/tests/ExpandersTest.php
+++ b/tests/ExpandersTest.php
@@ -78,7 +78,7 @@ final class ExpandersTest extends TestCase
             ['127.255.999.999', '@string@.isIp()', false],
             ['foo:bar:42:42', '@string@.isIp()', false],
             ['{"image":{"url":"http://image.com"}}', '{"image":"@json@.match({\"url\":\"@string@.isUrl()\"})"}', true],
-            ['{"image":{"url":null}}', '{"image":"@null@||@json@.match({\"url\":\"@string@.isUrl()\"})"}', true],
+            ['{"image":null}', '{"image":"@null@||@json@.match({\"url\":\"@string@.isUrl()\"})"}', true],
         ];
     }
 }

--- a/tests/ExpandersTest.php
+++ b/tests/ExpandersTest.php
@@ -79,6 +79,7 @@ final class ExpandersTest extends TestCase
             ['foo:bar:42:42', '@string@.isIp()', false],
             ['{"image":{"url":"http://image.com"}}', '{"image":"@json@.match({\"url\":\"@string@.isUrl()\"})"}', true],
             ['{"image":null}', '{"image":"@null@||@json@.match({\"url\":\"@string@.isUrl()\"})"}', true],
+            ['{"image":null}', '{"image":"@json@.oneOf(optional(), match({\"url\":\"@string@.isUrl()\"}) )"}', true],
         ];
     }
 }


### PR DESCRIPTION
This is continuation of #101 originally created by @partikus that introduce extremely flexible `match` expander. It also closes #133 

All examples will return true:
```php
(new MatcherFactory())->match(
  '{"image":null}',
  '{"image":"@null@||@json@.match({\"url\":\"@string@.isUrl()\"})"}'
);

(new MatcherFactory())->match(
  '{"image":{"url":"http://image.com"}}',
  '{"image":"@null@||@json@.match({\"url\":\"@string@.isUrl()\"})"}'
);

(new MatcherFactory())->match(
  '{"image":{"url":"http://image.com"}}',
  '{"image":"@json@.oneOf(optional(), match({\"url\":\"@string@.isUrl()\"}) )"}'
);
```