### PR TITLE
Added possibility to dump backtrace

### DIFF
--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -16,45 +16,45 @@ final class Backtrace
         $this->trace = [];
     }
 
-    public function matcherCanMatch(string $matcherClass, $value, bool $result) : void
+    public function matcherCanMatch(string $name, $value, bool $result) : void
     {
         $this->trace[] = \sprintf(
             '#%d Matcher %s %s match pattern "%s"',
             $this->entriesCount(),
-            $matcherClass,
+            $name,
             $result ? 'can' : 'can\'t',
             new SingleLineString((string) new StringConverter($value))
         );
     }
 
-    public function matcherEntrance(string $matcherClass, $value, $pattern) : void
+    public function matcherEntrance(string $name, $value, $pattern) : void
     {
         $this->trace[] = \sprintf(
             '#%d Matcher %s matching value "%s" with "%s" pattern',
             $this->entriesCount(),
-            $matcherClass,
+            $name,
             new SingleLineString((string) new StringConverter($value)),
             new SingleLineString((string) new StringConverter($pattern))
         );
     }
 
-    public function matcherSucceed(string $matcherClass, $value, $pattern) : void
+    public function matcherSucceed(string $name, $value, $pattern) : void
     {
         $this->trace[] = \sprintf(
             '#%d Matcher %s successfully matched value "%s" with "%s" pattern',
             $this->entriesCount(),
-            $matcherClass,
+            $name,
             new SingleLineString((string) new StringConverter($value)),
             new SingleLineString((string) new StringConverter($pattern))
         );
     }
 
-    public function matcherFailed(string $matcherClass, $value, $pattern, string $error) : void
+    public function matcherFailed(string $name, $value, $pattern, string $error) : void
     {
         $this->trace[] = \sprintf(
             '#%d Matcher %s failed to match value "%s" with "%s" pattern',
             $this->entriesCount(),
-            $matcherClass,
+            $name,
             new SingleLineString((string) new StringConverter($value)),
             new SingleLineString((string) new StringConverter($pattern))
         );
@@ -62,7 +62,7 @@ final class Backtrace
         $this->trace[] = \sprintf(
             '#%d Matcher %s error: %s',
             $this->entriesCount(),
-            $matcherClass,
+            $name,
             new SingleLineString($error)
         );
     }

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher;
 
+use Coduo\PHPMatcher\Value\SingleLineString;
 use Coduo\ToString\StringConverter;
 
 final class Backtrace
@@ -22,7 +23,7 @@ final class Backtrace
             $this->entriesCount(),
             $matcherClass,
             $result ? 'can' : 'can\'t',
-            new StringConverter($value)
+            new SingleLineString((string) new StringConverter($value))
         );
     }
 
@@ -32,8 +33,8 @@ final class Backtrace
             '#%d Matcher %s matching value "%s" with "%s" pattern',
             $this->entriesCount(),
             $matcherClass,
-            new StringConverter($value),
-            new StringConverter($pattern)
+            new SingleLineString((string) new StringConverter($value)),
+            new SingleLineString((string) new StringConverter($pattern))
         );
     }
 
@@ -43,8 +44,8 @@ final class Backtrace
             '#%d Matcher %s successfully matched value "%s" with "%s" pattern',
             $this->entriesCount(),
             $matcherClass,
-            new StringConverter($value),
-            new StringConverter($pattern)
+            new SingleLineString((string) new StringConverter($value)),
+            new SingleLineString((string) new StringConverter($pattern))
         );
     }
 
@@ -54,14 +55,15 @@ final class Backtrace
             '#%d Matcher %s failed to match value "%s" with "%s" pattern',
             $this->entriesCount(),
             $matcherClass,
-            new StringConverter($value),
-            new StringConverter($pattern)
+            new SingleLineString((string) new StringConverter($value)),
+            new SingleLineString((string) new StringConverter($pattern))
         );
+
         $this->trace[] = \sprintf(
             '#%d Matcher %s error: %s',
-            \count($this->trace),
+            $this->entriesCount(),
             $matcherClass,
-            $error
+            new SingleLineString($error)
         );
     }
 
@@ -75,9 +77,6 @@ final class Backtrace
         return $this->trace;
     }
 
-    /**
-     * @return int
-     */
     private function entriesCount(): int
     {
         return \count($this->trace) + 1;

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher;
+
+use Coduo\ToString\StringConverter;
+
+final class Backtrace
+{
+    private $trace;
+
+    public function __construct()
+    {
+        $this->trace = [];
+    }
+
+    public function matcherCanMatch(string $matcherClass, $value, bool $result) : void
+    {
+        $this->trace[] = \sprintf(
+            '#%d Matcher %s %s match pattern "%s"',
+            $this->entriesCount(),
+            $matcherClass,
+            $result ? 'can' : 'can\'t',
+            new StringConverter($value)
+        );
+    }
+
+    public function matcherEntrance(string $matcherClass, $value, $pattern) : void
+    {
+        $this->trace[] = \sprintf(
+            '#%d Matcher %s matching value "%s" with "%s" pattern',
+            $this->entriesCount(),
+            $matcherClass,
+            new StringConverter($value),
+            new StringConverter($pattern)
+        );
+    }
+
+    public function matcherSucceed(string $matcherClass, $value, $pattern) : void
+    {
+        $this->trace[] = \sprintf(
+            '#%d Matcher %s successfully matched value "%s" with "%s" pattern',
+            $this->entriesCount(),
+            $matcherClass,
+            new StringConverter($value),
+            new StringConverter($pattern)
+        );
+    }
+
+    public function matcherFailed(string $matcherClass, $value, $pattern, string $error) : void
+    {
+        $this->trace[] = \sprintf(
+            '#%d Matcher %s failed to match value "%s" with "%s" pattern',
+            $this->entriesCount(),
+            $matcherClass,
+            new StringConverter($value),
+            new StringConverter($pattern)
+        );
+        $this->trace[] = \sprintf(
+            '#%d Matcher %s error: %s',
+            \count($this->trace),
+            $matcherClass,
+            $error
+        );
+    }
+
+    public function __toString() : string
+    {
+        return \implode("\n", $this->trace);
+    }
+
+    public function raw() : array
+    {
+        return $this->trace;
+    }
+
+    /**
+     * @return int
+     */
+    private function entriesCount(): int
+    {
+        return \count($this->trace) + 1;
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,5 +6,5 @@ namespace Coduo\PHPMatcher;
 
 interface Factory
 {
-    public function createMatcher() : Matcher;
+    public function createMatcher(Backtrace $backtrace = null) : Matcher;
 }

--- a/src/Factory/MatcherFactory.php
+++ b/src/Factory/MatcherFactory.php
@@ -32,6 +32,7 @@ final class MatcherFactory implements Factory
         // 5) full text
 
         $chainMatcher = new Matcher\ChainMatcher(
+            'all',
             $backtrace,
             [
                 $scalarMatchers,
@@ -52,6 +53,7 @@ final class MatcherFactory implements Factory
 
         return new Matcher\ArrayMatcher(
             new Matcher\ChainMatcher(
+                'array',
                 $backtrace,
                 [
                     $orMatcher,
@@ -67,6 +69,7 @@ final class MatcherFactory implements Factory
     protected function buildScalarMatchers(Parser $parser, Backtrace $backtrace) : Matcher\ChainMatcher
     {
         return new Matcher\ChainMatcher(
+            'scalars',
             $backtrace,
             [
                 new Matcher\CallbackMatcher($backtrace),

--- a/src/Factory/MatcherFactory.php
+++ b/src/Factory/MatcherFactory.php
@@ -35,8 +35,8 @@ final class MatcherFactory implements Factory
             $backtrace,
             [
                 $scalarMatchers,
-                new Matcher\JsonMatcher($arrayMatcher),
-                new Matcher\XmlMatcher($arrayMatcher),
+                new Matcher\JsonMatcher($arrayMatcher, $backtrace),
+                new Matcher\XmlMatcher($arrayMatcher, $backtrace),
                 $arrayMatcher,
                 new Matcher\OrMatcher($backtrace, $scalarMatchers),
                 new Matcher\TextMatcher($scalarMatchers, $backtrace, $parser),
@@ -59,6 +59,7 @@ final class MatcherFactory implements Factory
                     new Matcher\TextMatcher($scalarMatchers, $backtrace, $parser)
                 ]
             ),
+            $backtrace,
             $parser
         );
     }

--- a/src/Factory/SimpleFactory.php
+++ b/src/Factory/SimpleFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Factory;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Factory;
 use Coduo\PHPMatcher\Matcher;
 
@@ -12,7 +13,7 @@ use Coduo\PHPMatcher\Matcher;
  */
 class SimpleFactory implements Factory
 {
-    public function createMatcher() : Matcher
+    public function createMatcher(Backtrace $backtrace = null) : Matcher
     {
         return (new MatcherFactory())->createMatcher();
     }

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -8,19 +8,27 @@ use Coduo\PHPMatcher\Matcher\ValueMatcher;
 
 final class Matcher
 {
-    private $matcher;
+    private $valueMatcher;
 
-    public function __construct(ValueMatcher $matcher)
+    private $backtrace;
+
+    public function __construct(ValueMatcher $valueMatcher, Backtrace $backtrace)
     {
-        $this->matcher = $matcher;
+        $this->valueMatcher = $valueMatcher;
+        $this->backtrace = $backtrace;
     }
 
     public function match($value, $pattern) : bool
     {
-        $result = $this->matcher->match($value, $pattern);
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
+        $result = $this->valueMatcher->match($value, $pattern);
 
         if ($result === true) {
-            $this->matcher->clearError();
+            $this->backtrace->matcherSucceed(self::class, $value, $pattern);
+            $this->valueMatcher->clearError();
+        } else {
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->valueMatcher->getError());
         }
 
         return $result;
@@ -31,6 +39,11 @@ final class Matcher
      */
     public function getError() : ?string
     {
-        return $this->matcher->getError();
+        return $this->valueMatcher->getError();
+    }
+
+    public function backtrace(): Backtrace
+    {
+        return $this->backtrace;
     }
 }

--- a/src/Matcher/BooleanMatcher.php
+++ b/src/Matcher/BooleanMatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Parser;
 use Coduo\ToString\StringConverter;
 
@@ -11,19 +12,27 @@ final class BooleanMatcher extends Matcher
 {
     const PATTERN = 'boolean';
 
+    private $backtrace;
     private $parser;
 
-    public function __construct(Parser $parser)
+    public function __construct(Backtrace $backtrace, Parser $parser)
     {
         $this->parser = $parser;
+        $this->backtrace = $backtrace;
     }
 
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         if (!\is_bool($value)) {
             $this->error = \sprintf('%s "%s" is not a valid boolean.', \gettype($value), new StringConverter($value));
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
+
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
 
         return true;
     }
@@ -31,9 +40,14 @@ final class BooleanMatcher extends Matcher
     public function canMatch($pattern) : bool
     {
         if (!\is_string($pattern)) {
+            $this->backtrace->matcherCanMatch(self::class, $pattern, false);
+
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        $result = $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/Matcher/CallbackMatcher.php
+++ b/src/Matcher/CallbackMatcher.php
@@ -4,15 +4,41 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
+use Coduo\ToString\StringConverter;
+
 final class CallbackMatcher extends Matcher
 {
+    /**
+     * @var Backtrace
+     */
+    private $backtrace;
+
+    public function __construct(Backtrace $backtrace)
+    {
+        $this->backtrace = $backtrace;
+    }
+
     public function match($value, $pattern) : bool
     {
-        return (boolean) $pattern->__invoke($value);
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+        $result = (boolean) $pattern->__invoke($value);
+
+        if ($result) {
+            $this->backtrace->matcherSucceed(self::class, $value, $pattern);
+        } else {
+            $this->error = \sprintf('Callback matcher failed for value %s', new StringConverter($value));
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+        }
+
+        return $result;
     }
 
     public function canMatch($pattern) : bool
     {
-        return \is_object($pattern) && \is_callable($pattern);
+        $result = \is_object($pattern) && \is_callable($pattern);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/Matcher/ChainMatcher.php
+++ b/src/Matcher/ChainMatcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Matcher;
 
 use Coduo\PHPMatcher\Backtrace;
+use Coduo\PHPMatcher\Value\SingleLineString;
 use Coduo\ToString\StringConverter;
 
 final class ChainMatcher extends Matcher
@@ -47,8 +48,8 @@ final class ChainMatcher extends Matcher
         if (!isset($this->error)) {
             $this->error = \sprintf(
                 'Any matcher from chain can\'t match value "%s" to pattern "%s"',
-                new StringConverter($value),
-                new StringConverter($pattern)
+                new SingleLineString((string) new StringConverter($value)),
+                new SingleLineString((string) new StringConverter($pattern))
             );
         }
 

--- a/src/Matcher/ChainMatcher.php
+++ b/src/Matcher/ChainMatcher.php
@@ -10,34 +10,29 @@ use Coduo\ToString\StringConverter;
 
 final class ChainMatcher extends Matcher
 {
-    /**
-     * @var Backtrace
-     */
+    private $name;
     private $backtrace;
-
-    /**
-     * @var ValueMatcher[]
-     */
     private $matchers;
 
     /**
      * @param Backtrace $backtrace
      * @param ValueMatcher[] $matchers
      */
-    public function __construct(Backtrace $backtrace, array $matchers = [])
+    public function __construct(string $name, Backtrace $backtrace, array $matchers = [])
     {
         $this->backtrace = $backtrace;
         $this->matchers = $matchers;
+        $this->name = $name;
     }
 
     public function match($value, $pattern) : bool
     {
-        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+        $this->backtrace->matcherEntrance($this->matcherName(), $value, $pattern);
 
         foreach ($this->matchers as $propertyMatcher) {
             if ($propertyMatcher->canMatch($pattern)) {
                 if (true === $propertyMatcher->match($value, $pattern)) {
-                    $this->backtrace->matcherSucceed(self::class, $value, $pattern);
+                    $this->backtrace->matcherSucceed($this->matcherName(), $value, $pattern);
                     return true;
                 }
 
@@ -53,15 +48,23 @@ final class ChainMatcher extends Matcher
             );
         }
 
-        $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+        $this->backtrace->matcherFailed($this->matcherName(), $value, $pattern, $this->error);
 
         return false;
     }
 
     public function canMatch($pattern) : bool
     {
-        $this->backtrace->matcherCanMatch(self::class, $pattern, true);
+        $this->backtrace->matcherCanMatch($this->matcherName(), $pattern, true);
 
         return true;
+    }
+
+    /**
+     * @return string
+     */
+    private function matcherName(): string
+    {
+        return \sprintf('%s (%s)', self::class, $this->name);
     }
 }

--- a/src/Matcher/ChainMatcher.php
+++ b/src/Matcher/ChainMatcher.php
@@ -4,33 +4,39 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\ToString\StringConverter;
 
 final class ChainMatcher extends Matcher
 {
+    /**
+     * @var Backtrace
+     */
+    private $backtrace;
+
     /**
      * @var ValueMatcher[]
      */
     private $matchers;
 
     /**
+     * @param Backtrace $backtrace
      * @param ValueMatcher[] $matchers
      */
-    public function __construct(array $matchers = [])
+    public function __construct(Backtrace $backtrace, array $matchers = [])
     {
+        $this->backtrace = $backtrace;
         $this->matchers = $matchers;
-    }
-
-    public function addMatcher(ValueMatcher $matcher)
-    {
-        $this->matchers[] = $matcher;
     }
 
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         foreach ($this->matchers as $propertyMatcher) {
             if ($propertyMatcher->canMatch($pattern)) {
                 if (true === $propertyMatcher->match($value, $pattern)) {
+                    $this->backtrace->matcherSucceed(self::class, $value, $pattern);
                     return true;
                 }
 
@@ -46,11 +52,15 @@ final class ChainMatcher extends Matcher
             );
         }
 
+        $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
         return false;
     }
 
     public function canMatch($pattern) : bool
     {
+        $this->backtrace->matcherCanMatch(self::class, $pattern, true);
+
         return true;
     }
 }

--- a/src/Matcher/DoubleMatcher.php
+++ b/src/Matcher/DoubleMatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Parser;
 use Coduo\ToString\StringConverter;
 
@@ -11,25 +12,35 @@ final class DoubleMatcher extends Matcher
 {
     const PATTERN = 'double';
 
+    private $backtrace;
     private $parser;
 
-    public function __construct(Parser $parser)
+    public function __construct(Backtrace $backtrace, Parser $parser)
     {
         $this->parser = $parser;
+        $this->backtrace = $backtrace;
     }
 
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         if (!\is_double($value)) {
             $this->error = \sprintf('%s "%s" is not a valid double.', \gettype($value), new StringConverter($value));
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
 
         $typePattern = $this->parser->parse($pattern);
         if (!$typePattern->matchExpanders($value)) {
             $this->error = $typePattern->getError();
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
+
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
 
         return true;
     }
@@ -37,9 +48,14 @@ final class DoubleMatcher extends Matcher
     public function canMatch($pattern) : bool
     {
         if (!\is_string($pattern)) {
+            $this->backtrace->matcherCanMatch(self::class, $pattern, false);
+
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        $result = $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/Matcher/ExpressionMatcher.php
+++ b/src/Matcher/ExpressionMatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\ToString\StringConverter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
@@ -11,21 +12,38 @@ final class ExpressionMatcher extends Matcher
 {
     const MATCH_PATTERN = "/^expr\((.*?)\)$/";
 
+    private $backtrace;
+
+    public function __construct(Backtrace $backtrace)
+    {
+        $this->backtrace = $backtrace;
+    }
+
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         $language = new ExpressionLanguage();
         \preg_match(self::MATCH_PATTERN, $pattern, $matches);
         $expressionResult = $language->evaluate($matches[1], ['value' => $value]);
 
         if (!$expressionResult) {
             $this->error = \sprintf('"%s" expression fails for value "%s".', $pattern, new StringConverter($value));
-        }
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
 
-        return (bool) $expressionResult;
+            return false;
+        } else {
+            $this->backtrace->matcherSucceed(self::class, $value, $pattern);
+
+            return true;
+        }
     }
 
     public function canMatch($pattern) : bool
     {
-        return \is_string($pattern) && 0 !== \preg_match(self::MATCH_PATTERN, $pattern);
+        $result = \is_string($pattern) && 0 !== \preg_match(self::MATCH_PATTERN, $pattern);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/Matcher/IntegerMatcher.php
+++ b/src/Matcher/IntegerMatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Parser;
 use Coduo\ToString\StringConverter;
 
@@ -11,10 +12,12 @@ final class IntegerMatcher extends Matcher
 {
     const PATTERN = 'integer';
 
+    private $backtrace;
     private $parser;
 
-    public function __construct(Parser $parser)
+    public function __construct(Backtrace $backtrace, Parser $parser)
     {
+        $this->backtrace = $backtrace;
         $this->parser = $parser;
     }
 
@@ -22,14 +25,19 @@ final class IntegerMatcher extends Matcher
     {
         if (!\is_integer($value)) {
             $this->error = \sprintf('%s "%s" is not a valid integer.', \gettype($value), new StringConverter($value));
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
             return false;
         }
 
         $typePattern = $this->parser->parse($pattern);
+
         if (!$typePattern->matchExpanders($value)) {
             $this->error = $typePattern->getError();
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
             return false;
         }
+
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
 
         return true;
     }
@@ -37,9 +45,14 @@ final class IntegerMatcher extends Matcher
     public function canMatch($pattern) : bool
     {
         if (!\is_string($pattern)) {
+            $this->backtrace->matcherCanMatch(self::class, $pattern, false);
+
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        $result = $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/Matcher/IntegerMatcher.php
+++ b/src/Matcher/IntegerMatcher.php
@@ -23,6 +23,8 @@ final class IntegerMatcher extends Matcher
 
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         if (!\is_integer($value)) {
             $this->error = \sprintf('%s "%s" is not a valid integer.', \gettype($value), new StringConverter($value));
             $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);

--- a/src/Matcher/JsonMatcher.php
+++ b/src/Matcher/JsonMatcher.php
@@ -6,6 +6,7 @@ namespace Coduo\PHPMatcher\Matcher;
 
 use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Matcher\Pattern\Assert\Json;
+use Coduo\PHPMatcher\Value\SingleLineString;
 use Coduo\ToString\StringConverter;
 
 final class JsonMatcher extends Matcher
@@ -50,8 +51,8 @@ final class JsonMatcher extends Matcher
         if (!$match) {
             $this->error = \sprintf(
                 'Value %s does not match pattern %s',
-                new StringConverter(Json::reformat($value)),
-                new StringConverter(Json::reformat($transformedPattern))
+                new SingleLineString((string) new StringConverter($value)),
+                new SingleLineString((string) new StringConverter($transformedPattern))
             );
 
             $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);

--- a/src/Matcher/JsonMatcher.php
+++ b/src/Matcher/JsonMatcher.php
@@ -50,8 +50,8 @@ final class JsonMatcher extends Matcher
         if (!$match) {
             $this->error = \sprintf(
                 'Value %s does not match pattern %s',
-                new StringConverter($value),
-                new StringConverter($pattern)
+                new StringConverter(Json::reformat($value)),
+                new StringConverter(Json::reformat($transformedPattern))
             );
 
             $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);

--- a/src/Matcher/JsonMatcher.php
+++ b/src/Matcher/JsonMatcher.php
@@ -4,31 +4,42 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Matcher\Pattern\Assert\Json;
 use Coduo\ToString\StringConverter;
 
 final class JsonMatcher extends Matcher
 {
     private $arrayMatcher;
+    private $backtrace;
 
-    public function __construct(ArrayMatcher $arrayMatcher)
+    public function __construct(ArrayMatcher $arrayMatcher, Backtrace $backtrace)
     {
         $this->arrayMatcher = $arrayMatcher;
+        $this->backtrace = $backtrace;
     }
 
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         if (parent::match($value, $pattern)) {
+            $this->backtrace->matcherSucceed(self::class, $value, $pattern);
+
             return true;
         }
 
         if (!Json::isValid($value)) {
             $this->error = \sprintf('Invalid given JSON of value. %s', Json::getErrorMessage());
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
 
         if (!Json::isValidPattern($pattern)) {
             $this->error = \sprintf('Invalid given JSON of pattern. %s', Json::getErrorMessage());
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
 
@@ -43,14 +54,21 @@ final class JsonMatcher extends Matcher
                 new StringConverter($pattern)
             );
 
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
+
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
 
         return true;
     }
 
     public function canMatch($pattern) : bool
     {
-        return Json::isValidPattern($pattern);
+        $result = Json::isValidPattern($pattern);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/Matcher/JsonObjectMatcher.php
+++ b/src/Matcher/JsonObjectMatcher.php
@@ -4,28 +4,37 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Matcher\Pattern\Assert\Json;
 use Coduo\PHPMatcher\Parser;
+use Coduo\ToString\StringConverter;
 
 final class JsonObjectMatcher extends Matcher
 {
     const JSON_PATTERN = 'json';
 
+    private $backtrace;
     private $parser;
 
-    public function __construct(Parser $parser)
+    public function __construct(Backtrace $backtrace, Parser $parser)
     {
+        $this->backtrace = $backtrace;
         $this->parser = $parser;
     }
 
     public function match($value, $pattern) : bool
     {
         if (!$this->isJsonPattern($pattern)) {
+            $this->error = \sprintf('%s "%s" is not a valid json.', \gettype($value), new StringConverter($value));
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
 
         if (!Json::isValid($value) && !\is_null($value) && !\is_array($value)) {
             $this->error = \sprintf('Invalid given JSON of value. %s', Json::getErrorMessage());
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
 
@@ -33,12 +42,17 @@ final class JsonObjectMatcher extends Matcher
             return $this->allExpandersMatch($value, $pattern);
         }
 
+        $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
         return false;
     }
 
     public function canMatch($pattern) : bool
     {
-        return \is_string($pattern) && $this->isJsonPattern($pattern);
+        $result = \is_string($pattern) && $this->isJsonPattern($pattern);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 
     private function isJsonPattern($pattern)
@@ -56,8 +70,11 @@ final class JsonObjectMatcher extends Matcher
 
         if (!$typePattern->matchExpanders($value)) {
             $this->error = $typePattern->getError();
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
             return false;
         }
+
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
 
         return true;
     }

--- a/src/Matcher/NullMatcher.php
+++ b/src/Matcher/NullMatcher.php
@@ -4,21 +4,35 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\ToString\StringConverter;
 
 final class NullMatcher extends Matcher
 {
     const MATCH_PATTERN = '/^@null@$/';
 
+    private $backtrace;
+
+    public function __construct(Backtrace $backtrace)
+    {
+        $this->backtrace = $backtrace;
+    }
+
     /**
      * {@inheritDoc}
      */
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         if (null !== $value) {
             $this->error = \sprintf('%s "%s" does not match null.', \gettype($value), new StringConverter($value));
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
+
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
 
         return true;
     }
@@ -28,6 +42,9 @@ final class NullMatcher extends Matcher
      */
     public function canMatch($pattern) : bool
     {
-        return \is_null($pattern) || (\is_string($pattern) && 0 !== \preg_match(self::MATCH_PATTERN, $pattern));
+        $result = \is_null($pattern) || (\is_string($pattern) && 0 !== \preg_match(self::MATCH_PATTERN, $pattern));
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/Matcher/Pattern/Assert/Json.php
+++ b/src/Matcher/Pattern/Assert/Json.php
@@ -45,6 +45,11 @@ final class Json
         );
     }
 
+    public static function reformat(string $json) : string
+    {
+        return \json_encode(\json_decode($json, true));
+    }
+
     public static function getErrorMessage()
     {
         switch (\json_last_error()) {

--- a/src/Matcher/ScalarMatcher.php
+++ b/src/Matcher/ScalarMatcher.php
@@ -4,22 +4,39 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\ToString\StringConverter;
 
 final class ScalarMatcher extends Matcher
 {
+    private $backtrace;
+
+    public function __construct(Backtrace $backtrace)
+    {
+        $this->backtrace = $backtrace;
+    }
+
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         if ($value !== $pattern) {
             $this->error = \sprintf('"%s" does not match "%s".', new StringConverter($value), new StringConverter($pattern));
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
+
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
 
         return true;
     }
 
     public function canMatch($pattern) : bool
     {
-        return \is_scalar($pattern);
+        $result = \is_scalar($pattern);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/Matcher/ScalarMatcher.php
+++ b/src/Matcher/ScalarMatcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Matcher;
 
 use Coduo\PHPMatcher\Backtrace;
+use Coduo\PHPMatcher\Value\SingleLineString;
 use Coduo\ToString\StringConverter;
 
 final class ScalarMatcher extends Matcher
@@ -21,7 +22,11 @@ final class ScalarMatcher extends Matcher
         $this->backtrace->matcherEntrance(self::class, $value, $pattern);
 
         if ($value !== $pattern) {
-            $this->error = \sprintf('"%s" does not match "%s".', new StringConverter($value), new StringConverter($pattern));
+            $this->error = \sprintf(
+                '"%s" does not match "%s".',
+                new SingleLineString((string) new StringConverter($value)),
+                new SingleLineString((string) new StringConverter($pattern))
+            );
             $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
 
             return false;

--- a/src/Matcher/StringMatcher.php
+++ b/src/Matcher/StringMatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Parser;
 use Coduo\ToString\StringConverter;
 
@@ -11,25 +12,36 @@ final class StringMatcher extends Matcher
 {
     const PATTERN = 'string';
 
+    private $backtrace;
     private $parser;
 
-    public function __construct(Parser $parser)
+    public function __construct(Backtrace $backtrace, Parser $parser)
     {
+        $this->backtrace = $backtrace;
         $this->parser = $parser;
     }
 
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         if (!\is_string($value)) {
             $this->error = \sprintf('%s "%s" is not a valid string.', \gettype($value), new StringConverter($value));
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
 
         $typePattern = $this->parser->parse($pattern);
+
         if (!$typePattern->matchExpanders($value)) {
             $this->error = $typePattern->getError();
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
+
             return false;
         }
+
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
 
         return true;
     }
@@ -37,9 +49,14 @@ final class StringMatcher extends Matcher
     public function canMatch($pattern) : bool
     {
         if (!\is_string($pattern)) {
+            $this->backtrace->matcherCanMatch(self::class, $pattern, false);
+            
             return false;
         }
 
-        return $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        $result = $this->parser->hasValidSyntax($pattern) && $this->parser->parse($pattern)->is(self::PATTERN);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/Matcher/TextMatcher.php
+++ b/src/Matcher/TextMatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Exception\UnknownTypeException;
 use Coduo\PHPMatcher\Matcher\Pattern\Assert\Json;
 use Coduo\PHPMatcher\Matcher\Pattern\Assert\Xml;
@@ -18,23 +19,14 @@ final class TextMatcher extends Matcher
 
     const PATTERN_REGEXP_PLACEHOLDER_TEMPLATE = '__PLACEHOLDER%d__';
 
-    /**
-     * @var Parser
-     */
     private $parser;
-
-    /**
-     * @var ValueMatcher
-     */
+    private $backtrace;
     private $matcher;
 
-    /**
-     * @param ValueMatcher $matcher
-     * @param Parser $parser
-     */
-    public function __construct(ValueMatcher $matcher, Parser $parser)
+    public function __construct(ValueMatcher $matcher, Backtrace $backtrace, Parser $parser)
     {
         $this->parser = $parser;
+        $this->backtrace = $backtrace;
         $this->matcher = $matcher;
     }
 
@@ -43,8 +35,12 @@ final class TextMatcher extends Matcher
      */
     public function match($value, $pattern) : bool
     {
+        $this->backtrace->matcherEntrance(self::class, $value, $pattern);
+
         if (!\is_string($value)) {
             $this->error = \sprintf('%s "%s" is not a valid string.', \gettype($value), new StringConverter($value));
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, (string) $this->error);
+
             return false;
         }
 
@@ -55,11 +51,15 @@ final class TextMatcher extends Matcher
             $patternRegex = $this->replacePlaceholderWithPatternRegexes($patternRegex, $patternsReplacedWithRegex);
         } catch (UnknownTypeException $exception) {
             $this->error = \sprintf('Type pattern "%s" is not supported by TextMatcher.', $exception->getType());
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, (string) $this->error);
+
             return false;
         }
 
         if (!\preg_match($patternRegex, $value, $matchedValues)) {
             $this->error = \sprintf('"%s" does not match "%s" pattern', $value, $pattern);
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, (string) $this->error);
+
             return false;
         }
 
@@ -67,15 +67,21 @@ final class TextMatcher extends Matcher
 
         if (\count($patternsReplacedWithRegex) !== \count($matchedValues)) {
             $this->error = 'Unexpected TextMatcher error.';
+            $this->backtrace->matcherFailed(self::class, $value, $pattern, (string) $this->error);
+
             return false;
         }
 
         foreach ($patternsReplacedWithRegex as $index => $typePattern) {
             if (!$typePattern->matchExpanders($matchedValues[$index])) {
                 $this->error = $typePattern->getError();
+                $this->backtrace->matcherFailed(self::class, $value, $pattern, (string) $this->error);
+
                 return false;
             }
         }
+
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
 
         return true;
     }
@@ -86,16 +92,25 @@ final class TextMatcher extends Matcher
     public function canMatch($pattern) : bool
     {
         if (!\is_string($pattern)) {
+            $this->backtrace->matcherCanMatch(self::class, $pattern, false);
+
             return false;
         }
 
         if (Json::isValidPattern($pattern)) {
+            $this->backtrace->matcherCanMatch(self::class, $pattern, false);
+
             return false;
         }
 
         if (Xml::isValid($pattern)) {
+            $this->backtrace->matcherCanMatch(self::class, $pattern, false);
+
             return false;
         }
+
+
+        $this->backtrace->matcherCanMatch(self::class, $pattern, true);
 
         return true;
     }

--- a/src/Matcher/WildcardMatcher.php
+++ b/src/Matcher/WildcardMatcher.php
@@ -4,17 +4,31 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
+
 final class WildcardMatcher extends Matcher
 {
     const MATCH_PATTERN = "/^@(\*|wildcard)@$/";
 
-    public function match($matcher, $pattern) : bool
+    private $backtrace;
+
+    public function __construct(Backtrace $backtrace)
     {
+        $this->backtrace = $backtrace;
+    }
+
+    public function match($value, $pattern) : bool
+    {
+        $this->backtrace->matcherSucceed(self::class, $value, $pattern);
+
         return true;
     }
 
     public function canMatch($pattern) : bool
     {
-        return \is_string($pattern) && 0 !== \preg_match(self::MATCH_PATTERN, $pattern);
+        $result = \is_string($pattern) && 0 !== \preg_match(self::MATCH_PATTERN, $pattern);
+        $this->backtrace->matcherCanMatch(self::class, $pattern, $result);
+
+        return $result;
     }
 }

--- a/src/PHPMatcher.php
+++ b/src/PHPMatcher.php
@@ -10,8 +10,19 @@ final class PHPMatcher
 {
     public static function match($value, $pattern, string &$error = null) : bool
     {
-        $factory = new MatcherFactory();
-        $matcher = $factory->createMatcher();
+        $matcher = (new MatcherFactory())->createMatcher();
+
+        if (!$matcher->match($value, $pattern)) {
+            $error = $matcher->getError();
+            return false;
+        }
+
+        return true;
+    }
+
+    public static function matchBacktrace($value, $pattern, Backtrace $backtrace, string &$error = null) : bool
+    {
+        $matcher = (new MatcherFactory())->createMatcher($backtrace);
 
         if (!$matcher->match($value, $pattern)) {
             $error = $matcher->getError();

--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\PHPUnit;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Factory\MatcherFactory;
 use Coduo\PHPMatcher\Matcher;
 use PHPUnit\Framework\Constraint\Constraint;
@@ -14,6 +15,7 @@ final class PHPMatcherConstraint extends Constraint
 {
     private $pattern;
     private $matcher;
+    private $backtrace;
     private $lastValue;
 
     public function __construct($pattern)
@@ -31,6 +33,7 @@ final class PHPMatcherConstraint extends Constraint
         }
 
         $this->pattern = $pattern;
+        $this->backtrace = new Backtrace();
         $this->matcher = $this->createMatcher();
     }
 
@@ -42,9 +45,14 @@ final class PHPMatcherConstraint extends Constraint
         return 'matches the pattern';
     }
 
+    protected function failureDescription($other): string
+    {
+        return parent::failureDescription($other) . ".\nError: " . $this->matcher->getError();
+    }
+
     protected function additionalFailureDescription($other) : string
     {
-        return $this->matcher->getError();
+        return  "Backtrace:\n" . (string) $this->backtrace;
     }
 
     protected function matches($value) : bool
@@ -54,9 +62,7 @@ final class PHPMatcherConstraint extends Constraint
 
     private function createMatcher() : Matcher
     {
-        $factory = new MatcherFactory();
-
-        return $factory->createMatcher();
+        return (new MatcherFactory())->createMatcher($this->backtrace);
     }
 
     /**

--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -50,11 +50,6 @@ final class PHPMatcherConstraint extends Constraint
         return parent::failureDescription($other) . ".\nError: " . $this->matcher->getError();
     }
 
-    protected function additionalFailureDescription($other) : string
-    {
-        return  "Backtrace:\n" . (string) $this->backtrace;
-    }
-
     protected function matches($value) : bool
     {
         return $this->matcher->match($this->lastValue = $value, $this->pattern);

--- a/src/Value/SingleLineString.php
+++ b/src/Value/SingleLineString.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Value;
+
+use Coduo\PHPMatcher\Matcher\Pattern\Assert\Json;
+
+final class SingleLineString
+{
+    /**
+     * @var string
+     */
+    private $raw;
+
+    public function __construct(string $raw)
+    {
+        $this->raw = $raw;
+    }
+
+    public function __toString() : string
+    {
+        $normalized = $this->raw;
+
+        if (Json::isValid($this->raw)) {
+            $normalized = Json::reformat($this->raw);
+        } else {
+            if (Json::isValid(Json::transformPattern($this->raw))) {
+                $normalized = Json::reformat(Json::transformPattern($this->raw));
+            }
+        }
+
+        return \str_replace(["\r\n", "\r", "\n"], ' ', $normalized);
+    }
+}

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -28,9 +28,9 @@ final class BacktraceTest extends TestCase
         $this->assertSame(
             <<<FAILED_BACKTRACE
 #1 Matcher Coduo\PHPMatcher\Matcher matching value "100" with "@string@" pattern
-#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "100" with "@string@" pattern
-#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
-#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "100" with "@string@" pattern
+#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) matching value "100" with "@string@" pattern
+#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@string@"
+#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "100" with "@string@" pattern
 #5 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
 #6 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
 #7 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
@@ -49,8 +49,8 @@ final class BacktraceTest extends TestCase
 #20 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@string@"
 #21 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@string@"
 #22 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@string@"
-#23 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "100" with "@string@" pattern
-#24 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "100" does not match "@string@".
+#23 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "100" with "@string@" pattern
+#24 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "100" does not match "@string@".
 #25 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher can't match pattern "@string@"
 #26 Matcher Coduo\PHPMatcher\Matcher\XmlMatcher can't match pattern "@string@"
 #27 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@string@"
@@ -58,8 +58,8 @@ final class BacktraceTest extends TestCase
 #29 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "100" with "@string@" pattern
 #30 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "100" with "@string@" pattern
 #31 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: integer "100" is not a valid string.
-#32 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "100" with "@string@" pattern
-#33 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: integer "100" is not a valid string.
+#32 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) failed to match value "100" with "@string@" pattern
+#33 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) error: integer "100" is not a valid string.
 #34 Matcher Coduo\PHPMatcher\Matcher failed to match value "100" with "@string@" pattern
 #35 Matcher Coduo\PHPMatcher\Matcher error: integer "100" is not a valid string.
 FAILED_BACKTRACE
@@ -75,17 +75,17 @@ FAILED_BACKTRACE
         $this->assertSame(
             <<<SUCCEED_BACKTRACE
 #1 Matcher Coduo\PHPMatcher\Matcher matching value "100" with "@string@" pattern
-#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "100" with "@string@" pattern
-#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
-#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "100" with "@string@" pattern
+#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) matching value "100" with "@string@" pattern
+#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@string@"
+#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "100" with "@string@" pattern
 #5 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
 #6 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
 #7 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
 #8 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
 #9 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "100" with "@string@" pattern
 #10 Matcher Coduo\PHPMatcher\Matcher\StringMatcher successfully matched value "100" with "@string@" pattern
-#11 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "100" with "@string@" pattern
-#12 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "100" with "@string@" pattern
+#11 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "100" with "@string@" pattern
+#12 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) successfully matched value "100" with "@string@" pattern
 #13 Matcher Coduo\PHPMatcher\Matcher successfully matched value "100" with "@string@" pattern
 SUCCEED_BACKTRACE
             ,

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Tests;
+
+use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\Matcher;
+use PHPUnit\Framework\TestCase;
+
+final class BacktraceTest extends TestCase
+{
+    /**
+     * @var Matcher
+     */
+    protected $matcher;
+
+    public function setUp() : void
+    {
+        $factory = new MatcherFactory();
+        $this->matcher = $factory->createMatcher();
+    }
+
+    public function test_backtrace_in_failed_simple_matching()
+    {
+        $this->matcher->match(100, '@string@');
+
+        $this->assertSame(
+            <<<FAILED_BACKTRACE
+#1 Matcher Coduo\PHPMatcher\Matcher matching value "100" with "@string@" pattern
+#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "100" with "@string@" pattern
+#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
+#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "100" with "@string@" pattern
+#5 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
+#6 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
+#7 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
+#8 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
+#9 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "100" with "@string@" pattern
+#10 Matcher Coduo\PHPMatcher\Matcher\StringMatcher failed to match value "100" with "@string@" pattern
+#11 Matcher Coduo\PHPMatcher\Matcher\StringMatcher error: integer "100" is not a valid string.
+#12 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@string@"
+#13 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "@string@"
+#14 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "@string@"
+#15 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "@string@"
+#16 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "@string@"
+#17 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "100" with "@string@" pattern
+#18 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "100" with "@string@" pattern
+#19 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "100" does not match "@string@".
+#20 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@string@"
+#21 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@string@"
+#22 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@string@"
+#23 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "100" with "@string@" pattern
+#24 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "100" does not match "@string@".
+#25 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher can't match pattern "@string@"
+#26 Matcher Coduo\PHPMatcher\Matcher\XmlMatcher can't match pattern "@string@"
+#27 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@string@"
+#28 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@string@"
+#29 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "100" with "@string@" pattern
+#30 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "100" with "@string@" pattern
+#31 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: integer "100" is not a valid string.
+#32 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "100" with "@string@" pattern
+#33 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: integer "100" is not a valid string.
+#34 Matcher Coduo\PHPMatcher\Matcher failed to match value "100" with "@string@" pattern
+#35 Matcher Coduo\PHPMatcher\Matcher error: integer "100" is not a valid string.
+FAILED_BACKTRACE
+            ,
+            (string) $this->matcher->backtrace()
+        );
+    }
+
+    public function test_backtrace_in_succeed_simple_matching()
+    {
+        $this->matcher->match('100', '@string@');
+
+        $this->assertSame(
+            <<<SUCCEED_BACKTRACE
+#1 Matcher Coduo\PHPMatcher\Matcher matching value "100" with "@string@" pattern
+#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "100" with "@string@" pattern
+#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
+#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "100" with "@string@" pattern
+#5 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
+#6 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
+#7 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
+#8 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
+#9 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "100" with "@string@" pattern
+#10 Matcher Coduo\PHPMatcher\Matcher\StringMatcher successfully matched value "100" with "@string@" pattern
+#11 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "100" with "@string@" pattern
+#12 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "100" with "@string@" pattern
+#13 Matcher Coduo\PHPMatcher\Matcher successfully matched value "100" with "@string@" pattern
+SUCCEED_BACKTRACE
+            ,
+            (string) $this->matcher->backtrace()
+        );
+    }
+
+    public function test_backtrace_in_failed_complex_matching()
+    {
+        $this->matcher->match(
+            /** @lang JSON */
+            '{
+                "users":[
+                    {
+                        "id": 131,
+                        "firstName": "Norbert",
+                        "lastName": "Orzechowicz",
+                        "enabled": true,
+                        "roles": ["ROLE_DEVELOPER"]
+                    },
+                    {
+                        "id": 132,
+                        "firstName": "Michał",
+                        "lastName": "Dąbrowski",
+                        "enabled": false,
+                        "roles": ["ROLE_DEVELOPER"]
+                    }
+                ],
+                "prevPage": "http:\/\/example.com\/api\/users\/1?limit=2",
+                "nextPage": "http:\/\/example.com\/api\/users\/3?limit=2"
+            }',
+            /** @lang JSON */
+            '{
+                "users":[
+                    {
+                        "id": "@integer@",
+                        "firstName":"Norbert",
+                        "lastName":"Orzechowicz",
+                        "enabled": "@boolean@",
+                        "roles": "@array@"
+                    },
+                    {
+                        "id": "@integer@",
+                        "firstName": "Michał",
+                        "lastName": "Dąbrowski",
+                        "enabled": "expr(value == true)",
+                        "roles": "@array@"
+                    }
+                ],
+                "prevPage": "@string@",
+                "nextPage": "@string@"
+            }'
+        );
+
+        // Uncomment when backtrace logic changes, run tests and then commit again.
+        //\file_put_contents(__DIR__ . '/BacktraceTest/failed_complex_matching_expected_trace.txt', (string) $this->matcher->backtrace());
+
+        $this->assertSame(
+            \file_get_contents(__DIR__ . '/BacktraceTest/failed_complex_matching_expected_trace.txt'),
+            (string) $this->matcher->backtrace()
+        );
+    }
+
+    public function test_backtrace_in_succeed_complex_matching()
+    {
+        $this->matcher->match(
+        /** @lang JSON */
+            '{
+                "users":[
+                    {
+                        "id": 131,
+                        "firstName": "Norbert",
+                        "lastName": "Orzechowicz",
+                        "enabled": true,
+                        "roles": ["ROLE_DEVELOPER"]
+                    },
+                    {
+                        "id": 132,
+                        "firstName": "Michał",
+                        "lastName": "Dąbrowski",
+                        "enabled": false,
+                        "roles": ["ROLE_DEVELOPER"]
+                    }
+                ],
+                "prevPage": "http:\/\/example.com\/api\/users\/1?limit=2",
+                "nextPage": "http:\/\/example.com\/api\/users\/3?limit=2"
+            }',
+            /** @lang JSON */
+            '{
+                "users":[
+                    {
+                        "id": "@integer@",
+                        "firstName":"Norbert",
+                        "lastName":"Orzechowicz",
+                        "enabled": "@boolean@",
+                        "roles": "@array@"
+                    },
+                    {
+                        "id": "@integer@",
+                        "firstName": "Michał",
+                        "lastName": "Dąbrowski",
+                        "enabled": "expr(value == false)",
+                        "roles": "@array@"
+                    }
+                ],
+                "prevPage": "@string@",
+                "nextPage": "@string@"
+            }'
+        );
+
+        // Uncomment when backtrace logic changes, run tests and then commit again.
+        //\file_put_contents(__DIR__ . '/BacktraceTest/succeed_complex_matching_expected_trace.txt', (string) $this->matcher->backtrace());
+
+        $this->assertSame(
+            \file_get_contents(__DIR__ . '/BacktraceTest/succeed_complex_matching_expected_trace.txt'),
+            (string) $this->matcher->backtrace()
+        );
+    }
+}

--- a/tests/BacktraceTest/failed_complex_matching_expected_trace.txt
+++ b/tests/BacktraceTest/failed_complex_matching_expected_trace.txt
@@ -1,0 +1,276 @@
+#1 Matcher Coduo\PHPMatcher\Matcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#5 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#6 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#7 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#8 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#9 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#10 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#11 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#12 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#13 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#14 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#15 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#16 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#17 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#18 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#19 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#20 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#21 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#22 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#23 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#24 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher matching value "Array(3)" with "Array(3)" pattern
+#25 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(2)"
+#26 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(2)" with "Array(2)" pattern
+#27 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(2)"
+#28 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(2)"
+#29 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(2)" with "Array(2)" pattern
+#30 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(2)"
+#31 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(2)"
+#32 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(2)"
+#33 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Array(2)"
+#34 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Array(2)"
+#35 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Array(2)"
+#36 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Array(2)"
+#37 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Array(2)"
+#38 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can't match pattern "Array(2)"
+#39 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(2)"
+#40 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(2)"
+#41 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(2)"
+#42 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(2)" with "Array(2)" pattern
+#43 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#44 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(2)"
+#45 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(2)" with "Array(2)" pattern
+#46 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#47 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
+#48 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#49 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
+#50 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
+#51 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#52 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
+#53 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
+#54 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
+#55 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Array(5)"
+#56 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Array(5)"
+#57 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Array(5)"
+#58 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Array(5)"
+#59 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Array(5)"
+#60 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can't match pattern "Array(5)"
+#61 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
+#62 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
+#63 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
+#64 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
+#65 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#66 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
+#67 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
+#68 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#69 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
+#70 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "131" with "@integer@" pattern
+#71 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
+#72 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
+#73 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "131" with "@integer@" pattern
+#74 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
+#75 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
+#76 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
+#77 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@integer@"
+#78 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
+#79 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "131" with "@integer@" pattern
+#80 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "131" with "@integer@" pattern
+#81 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "131" with "@integer@" pattern
+#82 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "131" with "@integer@" pattern
+#83 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Norbert"
+#84 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Norbert" with "Norbert" pattern
+#85 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Norbert"
+#86 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Norbert"
+#87 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Norbert" with "Norbert" pattern
+#88 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Norbert"
+#89 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Norbert"
+#90 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Norbert"
+#91 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Norbert"
+#92 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Norbert"
+#93 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Norbert"
+#94 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Norbert"
+#95 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Norbert"
+#96 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Norbert"
+#97 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Norbert" with "Norbert" pattern
+#98 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Norbert" with "Norbert" pattern
+#99 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Norbert" with "Norbert" pattern
+#100 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Norbert" with "Norbert" pattern
+#101 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Orzechowicz"
+#102 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#103 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Orzechowicz"
+#104 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Orzechowicz"
+#105 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#106 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Orzechowicz"
+#107 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Orzechowicz"
+#108 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Orzechowicz"
+#109 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Orzechowicz"
+#110 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Orzechowicz"
+#111 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Orzechowicz"
+#112 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Orzechowicz"
+#113 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Orzechowicz"
+#114 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Orzechowicz"
+#115 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#116 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#117 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#118 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#119 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@boolean@"
+#120 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "true" with "@boolean@" pattern
+#121 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@boolean@"
+#122 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@boolean@"
+#123 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "true" with "@boolean@" pattern
+#124 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@boolean@"
+#125 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@boolean@"
+#126 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@boolean@"
+#127 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@boolean@"
+#128 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@boolean@"
+#129 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can match pattern "@boolean@"
+#130 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher matching value "true" with "@boolean@" pattern
+#131 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher successfully matched value "true" with "@boolean@" pattern
+#132 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "true" with "@boolean@" pattern
+#133 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "true" with "@boolean@" pattern
+#134 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
+#135 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#136 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@array@"
+#137 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
+#138 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#139 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@array@"
+#140 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@array@"
+#141 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@array@"
+#142 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@array@"
+#143 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@array@"
+#144 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "@array@"
+#145 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "@array@"
+#146 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "@array@"
+#147 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "@array@"
+#148 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Array(1)" with "@array@" pattern
+#149 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "Array(1)" with "@array@" pattern
+#150 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "Array(1)" does not match "@array@".
+#151 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@array@"
+#152 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@array@"
+#153 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@array@"
+#154 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
+#155 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#156 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@array@"
+#157 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "Array(1)" with "@array@" pattern
+#158 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "Array(1)" with "@array@" pattern
+#159 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: array "Array(1)" is not a valid string.
+#160 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
+#161 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: array "Array(1)" is not a valid string.
+#162 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(1)" with "@array@" pattern
+#163 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
+#164 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#165 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
+#166 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
+#167 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#168 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
+#169 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
+#170 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
+#171 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Array(5)"
+#172 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Array(5)"
+#173 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Array(5)"
+#174 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Array(5)"
+#175 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Array(5)"
+#176 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can't match pattern "Array(5)"
+#177 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
+#178 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
+#179 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
+#180 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
+#181 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#182 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
+#183 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
+#184 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#185 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
+#186 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "132" with "@integer@" pattern
+#187 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
+#188 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
+#189 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "132" with "@integer@" pattern
+#190 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
+#191 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
+#192 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
+#193 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@integer@"
+#194 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
+#195 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "132" with "@integer@" pattern
+#196 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "132" with "@integer@" pattern
+#197 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "132" with "@integer@" pattern
+#198 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "132" with "@integer@" pattern
+#199 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Michał"
+#200 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Michał" with "Michał" pattern
+#201 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Michał"
+#202 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Michał"
+#203 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Michał" with "Michał" pattern
+#204 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Michał"
+#205 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Michał"
+#206 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Michał"
+#207 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Michał"
+#208 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Michał"
+#209 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Michał"
+#210 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Michał"
+#211 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Michał"
+#212 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Michał"
+#213 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Michał" with "Michał" pattern
+#214 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Michał" with "Michał" pattern
+#215 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Michał" with "Michał" pattern
+#216 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Michał" with "Michał" pattern
+#217 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Dąbrowski"
+#218 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#219 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Dąbrowski"
+#220 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Dąbrowski"
+#221 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#222 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Dąbrowski"
+#223 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Dąbrowski"
+#224 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Dąbrowski"
+#225 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Dąbrowski"
+#226 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Dąbrowski"
+#227 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Dąbrowski"
+#228 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Dąbrowski"
+#229 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Dąbrowski"
+#230 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Dąbrowski"
+#231 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#232 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#233 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#234 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#235 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "expr(value == true)"
+#236 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "false" with "expr(value == true)" pattern
+#237 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "expr(value == true)"
+#238 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "expr(value == true)"
+#239 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "false" with "expr(value == true)" pattern
+#240 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "expr(value == true)"
+#241 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can match pattern "expr(value == true)"
+#242 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher matching value "false" with "expr(value == true)" pattern
+#243 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher failed to match value "false" with "expr(value == true)" pattern
+#244 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher error: "expr(value == true)" expression fails for value "false".
+#245 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "expr(value == true)"
+#246 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "expr(value == true)"
+#247 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "expr(value == true)"
+#248 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "expr(value == true)"
+#249 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "expr(value == true)"
+#250 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "expr(value == true)"
+#251 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "expr(value == true)"
+#252 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "false" with "expr(value == true)" pattern
+#253 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "false" with "expr(value == true)" pattern
+#254 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "false" does not match "expr(value == true)".
+#255 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "expr(value == true)"
+#256 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "expr(value == true)"
+#257 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "expr(value == true)"
+#258 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "false" with "expr(value == true)" pattern
+#259 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "false" does not match "expr(value == true)".
+#260 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "expr(value == true)"
+#261 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "false" with "expr(value == true)" pattern
+#262 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "false" with "expr(value == true)" pattern
+#263 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: boolean "false" is not a valid string.
+#264 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "false" with "expr(value == true)" pattern
+#265 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: boolean "false" is not a valid string.
+#266 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher failed to match value "Array(3)" with "Array(3)" pattern
+#267 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher error: boolean "false" is not a valid string.
+#268 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#269 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher error: Value {"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"} does not match pattern {"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}
+#270 Matcher Coduo\PHPMatcher\Matcher\XmlMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#271 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#272 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#273 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#274 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: Value {"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"} does not match pattern {"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}
+#275 Matcher Coduo\PHPMatcher\Matcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#276 Matcher Coduo\PHPMatcher\Matcher error: Value {"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"} does not match pattern {"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}

--- a/tests/BacktraceTest/failed_complex_matching_expected_trace.txt
+++ b/tests/BacktraceTest/failed_complex_matching_expected_trace.txt
@@ -1,7 +1,7 @@
 #1 Matcher Coduo\PHPMatcher\Matcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
-#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
 #5 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #6 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #7 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
@@ -17,16 +17,16 @@
 #17 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #18 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #19 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
-#20 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#21 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#20 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#21 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
 #22 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #23 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
 #24 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher matching value "Array(3)" with "Array(3)" pattern
-#25 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(2)"
-#26 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(2)" with "Array(2)" pattern
+#25 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Array(2)"
+#26 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(2)" with "Array(2)" pattern
 #27 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(2)"
-#28 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(2)"
-#29 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(2)" with "Array(2)" pattern
+#28 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Array(2)"
+#29 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(2)" with "Array(2)" pattern
 #30 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(2)"
 #31 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(2)"
 #32 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(2)"
@@ -39,16 +39,16 @@
 #39 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(2)"
 #40 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(2)"
 #41 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(2)"
-#42 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(2)" with "Array(2)" pattern
-#43 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#42 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(2)" with "Array(2)" pattern
+#43 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
 #44 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(2)"
-#45 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(2)" with "Array(2)" pattern
-#46 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
-#47 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
-#48 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#45 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(2)" with "Array(2)" pattern
+#46 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#47 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Array(5)"
+#48 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(5)" with "Array(5)" pattern
 #49 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
-#50 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
-#51 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#50 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Array(5)"
+#51 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(5)" with "Array(5)" pattern
 #52 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
 #53 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
 #54 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
@@ -61,16 +61,16 @@
 #61 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
 #62 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
 #63 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
-#64 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
-#65 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#64 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(5)" with "Array(5)" pattern
+#65 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
 #66 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
-#67 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
-#68 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
-#69 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
-#70 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "131" with "@integer@" pattern
+#67 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(5)" with "Array(5)" pattern
+#68 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#69 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@integer@"
+#70 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "131" with "@integer@" pattern
 #71 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
-#72 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
-#73 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "131" with "@integer@" pattern
+#72 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@integer@"
+#73 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "131" with "@integer@" pattern
 #74 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
 #75 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
 #76 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
@@ -78,13 +78,13 @@
 #78 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
 #79 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "131" with "@integer@" pattern
 #80 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "131" with "@integer@" pattern
-#81 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "131" with "@integer@" pattern
-#82 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "131" with "@integer@" pattern
-#83 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Norbert"
-#84 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Norbert" with "Norbert" pattern
+#81 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "131" with "@integer@" pattern
+#82 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "131" with "@integer@" pattern
+#83 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Norbert"
+#84 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Norbert" with "Norbert" pattern
 #85 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Norbert"
-#86 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Norbert"
-#87 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Norbert" with "Norbert" pattern
+#86 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Norbert"
+#87 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Norbert" with "Norbert" pattern
 #88 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Norbert"
 #89 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Norbert"
 #90 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Norbert"
@@ -96,13 +96,13 @@
 #96 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Norbert"
 #97 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Norbert" with "Norbert" pattern
 #98 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Norbert" with "Norbert" pattern
-#99 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Norbert" with "Norbert" pattern
-#100 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Norbert" with "Norbert" pattern
-#101 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Orzechowicz"
-#102 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#99 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Norbert" with "Norbert" pattern
+#100 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Norbert" with "Norbert" pattern
+#101 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Orzechowicz"
+#102 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Orzechowicz" with "Orzechowicz" pattern
 #103 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Orzechowicz"
-#104 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Orzechowicz"
-#105 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#104 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Orzechowicz"
+#105 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Orzechowicz" with "Orzechowicz" pattern
 #106 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Orzechowicz"
 #107 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Orzechowicz"
 #108 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Orzechowicz"
@@ -114,13 +114,13 @@
 #114 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Orzechowicz"
 #115 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
 #116 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#117 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#118 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#119 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@boolean@"
-#120 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "true" with "@boolean@" pattern
+#117 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#118 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#119 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@boolean@"
+#120 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "true" with "@boolean@" pattern
 #121 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@boolean@"
-#122 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@boolean@"
-#123 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "true" with "@boolean@" pattern
+#122 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@boolean@"
+#123 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "true" with "@boolean@" pattern
 #124 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@boolean@"
 #125 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@boolean@"
 #126 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@boolean@"
@@ -129,13 +129,13 @@
 #129 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can match pattern "@boolean@"
 #130 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher matching value "true" with "@boolean@" pattern
 #131 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher successfully matched value "true" with "@boolean@" pattern
-#132 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "true" with "@boolean@" pattern
-#133 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "true" with "@boolean@" pattern
-#134 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
-#135 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#132 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "true" with "@boolean@" pattern
+#133 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "true" with "@boolean@" pattern
+#134 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@array@"
+#135 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(1)" with "@array@" pattern
 #136 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@array@"
-#137 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
-#138 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#137 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@array@"
+#138 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(1)" with "@array@" pattern
 #139 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@array@"
 #140 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@array@"
 #141 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@array@"
@@ -151,20 +151,20 @@
 #151 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@array@"
 #152 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@array@"
 #153 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@array@"
-#154 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
-#155 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#154 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(1)" with "@array@" pattern
+#155 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(1)" does not match "@array@".
 #156 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@array@"
 #157 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "Array(1)" with "@array@" pattern
 #158 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "Array(1)" with "@array@" pattern
 #159 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: array "Array(1)" is not a valid string.
-#160 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
-#161 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: array "Array(1)" is not a valid string.
+#160 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(1)" with "@array@" pattern
+#161 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: array "Array(1)" is not a valid string.
 #162 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(1)" with "@array@" pattern
-#163 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
-#164 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#163 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Array(5)"
+#164 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(5)" with "Array(5)" pattern
 #165 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
-#166 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
-#167 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#166 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Array(5)"
+#167 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(5)" with "Array(5)" pattern
 #168 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
 #169 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
 #170 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
@@ -177,16 +177,16 @@
 #177 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
 #178 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
 #179 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
-#180 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
-#181 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#180 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(5)" with "Array(5)" pattern
+#181 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(1)" does not match "@array@".
 #182 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
-#183 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
-#184 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
-#185 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
-#186 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "132" with "@integer@" pattern
+#183 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(5)" with "Array(5)" pattern
+#184 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: "Array(1)" does not match "@array@".
+#185 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@integer@"
+#186 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "132" with "@integer@" pattern
 #187 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
-#188 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
-#189 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "132" with "@integer@" pattern
+#188 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@integer@"
+#189 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "132" with "@integer@" pattern
 #190 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
 #191 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
 #192 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
@@ -194,13 +194,13 @@
 #194 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
 #195 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "132" with "@integer@" pattern
 #196 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "132" with "@integer@" pattern
-#197 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "132" with "@integer@" pattern
-#198 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "132" with "@integer@" pattern
-#199 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Michał"
-#200 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Michał" with "Michał" pattern
+#197 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "132" with "@integer@" pattern
+#198 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "132" with "@integer@" pattern
+#199 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Michał"
+#200 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Michał" with "Michał" pattern
 #201 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Michał"
-#202 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Michał"
-#203 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Michał" with "Michał" pattern
+#202 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Michał"
+#203 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Michał" with "Michał" pattern
 #204 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Michał"
 #205 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Michał"
 #206 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Michał"
@@ -212,13 +212,13 @@
 #212 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Michał"
 #213 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Michał" with "Michał" pattern
 #214 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Michał" with "Michał" pattern
-#215 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Michał" with "Michał" pattern
-#216 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Michał" with "Michał" pattern
-#217 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Dąbrowski"
-#218 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#215 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Michał" with "Michał" pattern
+#216 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Michał" with "Michał" pattern
+#217 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Dąbrowski"
+#218 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Dąbrowski" with "Dąbrowski" pattern
 #219 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Dąbrowski"
-#220 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Dąbrowski"
-#221 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#220 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Dąbrowski"
+#221 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Dąbrowski" with "Dąbrowski" pattern
 #222 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Dąbrowski"
 #223 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Dąbrowski"
 #224 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Dąbrowski"
@@ -230,13 +230,13 @@
 #230 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Dąbrowski"
 #231 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
 #232 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#233 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#234 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#235 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "expr(value == true)"
-#236 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "false" with "expr(value == true)" pattern
+#233 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#234 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#235 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "expr(value == true)"
+#236 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "false" with "expr(value == true)" pattern
 #237 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "expr(value == true)"
-#238 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "expr(value == true)"
-#239 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "false" with "expr(value == true)" pattern
+#238 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "expr(value == true)"
+#239 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "false" with "expr(value == true)" pattern
 #240 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "expr(value == true)"
 #241 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can match pattern "expr(value == true)"
 #242 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher matching value "false" with "expr(value == true)" pattern
@@ -255,14 +255,14 @@
 #255 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "expr(value == true)"
 #256 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "expr(value == true)"
 #257 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "expr(value == true)"
-#258 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "false" with "expr(value == true)" pattern
-#259 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "false" does not match "expr(value == true)".
+#258 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "false" with "expr(value == true)" pattern
+#259 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "false" does not match "expr(value == true)".
 #260 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "expr(value == true)"
 #261 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "false" with "expr(value == true)" pattern
 #262 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "false" with "expr(value == true)" pattern
 #263 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: boolean "false" is not a valid string.
-#264 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "false" with "expr(value == true)" pattern
-#265 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: boolean "false" is not a valid string.
+#264 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "false" with "expr(value == true)" pattern
+#265 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: boolean "false" is not a valid string.
 #266 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher failed to match value "Array(3)" with "Array(3)" pattern
 #267 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher error: boolean "false" is not a valid string.
 #268 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
@@ -270,7 +270,7 @@
 #270 Matcher Coduo\PHPMatcher\Matcher\XmlMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #271 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #272 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
-#273 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#274 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: Value {"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"} does not match pattern {"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}
+#273 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#274 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) error: Value {"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"} does not match pattern {"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}
 #275 Matcher Coduo\PHPMatcher\Matcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
 #276 Matcher Coduo\PHPMatcher\Matcher error: Value {"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"} does not match pattern {"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}

--- a/tests/BacktraceTest/succeed_complex_matching_expected_trace.txt
+++ b/tests/BacktraceTest/succeed_complex_matching_expected_trace.txt
@@ -1,7 +1,7 @@
 #1 Matcher Coduo\PHPMatcher\Matcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
-#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
 #5 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #6 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #7 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
@@ -17,16 +17,16 @@
 #17 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #18 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #19 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
-#20 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#21 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#20 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#21 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
 #22 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
 #23 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
 #24 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher matching value "Array(3)" with "Array(3)" pattern
-#25 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(2)"
-#26 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(2)" with "Array(2)" pattern
+#25 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Array(2)"
+#26 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(2)" with "Array(2)" pattern
 #27 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(2)"
-#28 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(2)"
-#29 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(2)" with "Array(2)" pattern
+#28 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Array(2)"
+#29 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(2)" with "Array(2)" pattern
 #30 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(2)"
 #31 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(2)"
 #32 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(2)"
@@ -39,16 +39,16 @@
 #39 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(2)"
 #40 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(2)"
 #41 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(2)"
-#42 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(2)" with "Array(2)" pattern
-#43 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#42 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(2)" with "Array(2)" pattern
+#43 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
 #44 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(2)"
-#45 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(2)" with "Array(2)" pattern
-#46 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
-#47 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
-#48 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#45 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(2)" with "Array(2)" pattern
+#46 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#47 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Array(5)"
+#48 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(5)" with "Array(5)" pattern
 #49 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
-#50 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
-#51 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#50 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Array(5)"
+#51 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(5)" with "Array(5)" pattern
 #52 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
 #53 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
 #54 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
@@ -61,16 +61,16 @@
 #61 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
 #62 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
 #63 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
-#64 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
-#65 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#64 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(5)" with "Array(5)" pattern
+#65 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
 #66 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
-#67 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
-#68 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
-#69 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
-#70 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "131" with "@integer@" pattern
+#67 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(5)" with "Array(5)" pattern
+#68 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#69 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@integer@"
+#70 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "131" with "@integer@" pattern
 #71 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
-#72 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
-#73 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "131" with "@integer@" pattern
+#72 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@integer@"
+#73 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "131" with "@integer@" pattern
 #74 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
 #75 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
 #76 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
@@ -78,13 +78,13 @@
 #78 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
 #79 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "131" with "@integer@" pattern
 #80 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "131" with "@integer@" pattern
-#81 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "131" with "@integer@" pattern
-#82 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "131" with "@integer@" pattern
-#83 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Norbert"
-#84 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Norbert" with "Norbert" pattern
+#81 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "131" with "@integer@" pattern
+#82 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "131" with "@integer@" pattern
+#83 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Norbert"
+#84 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Norbert" with "Norbert" pattern
 #85 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Norbert"
-#86 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Norbert"
-#87 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Norbert" with "Norbert" pattern
+#86 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Norbert"
+#87 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Norbert" with "Norbert" pattern
 #88 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Norbert"
 #89 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Norbert"
 #90 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Norbert"
@@ -96,13 +96,13 @@
 #96 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Norbert"
 #97 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Norbert" with "Norbert" pattern
 #98 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Norbert" with "Norbert" pattern
-#99 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Norbert" with "Norbert" pattern
-#100 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Norbert" with "Norbert" pattern
-#101 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Orzechowicz"
-#102 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#99 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Norbert" with "Norbert" pattern
+#100 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Norbert" with "Norbert" pattern
+#101 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Orzechowicz"
+#102 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Orzechowicz" with "Orzechowicz" pattern
 #103 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Orzechowicz"
-#104 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Orzechowicz"
-#105 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#104 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Orzechowicz"
+#105 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Orzechowicz" with "Orzechowicz" pattern
 #106 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Orzechowicz"
 #107 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Orzechowicz"
 #108 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Orzechowicz"
@@ -114,13 +114,13 @@
 #114 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Orzechowicz"
 #115 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
 #116 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#117 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#118 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#119 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@boolean@"
-#120 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "true" with "@boolean@" pattern
+#117 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#118 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#119 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@boolean@"
+#120 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "true" with "@boolean@" pattern
 #121 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@boolean@"
-#122 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@boolean@"
-#123 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "true" with "@boolean@" pattern
+#122 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@boolean@"
+#123 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "true" with "@boolean@" pattern
 #124 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@boolean@"
 #125 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@boolean@"
 #126 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@boolean@"
@@ -129,13 +129,13 @@
 #129 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can match pattern "@boolean@"
 #130 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher matching value "true" with "@boolean@" pattern
 #131 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher successfully matched value "true" with "@boolean@" pattern
-#132 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "true" with "@boolean@" pattern
-#133 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "true" with "@boolean@" pattern
-#134 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
-#135 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#132 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "true" with "@boolean@" pattern
+#133 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "true" with "@boolean@" pattern
+#134 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@array@"
+#135 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(1)" with "@array@" pattern
 #136 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@array@"
-#137 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
-#138 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#137 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@array@"
+#138 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(1)" with "@array@" pattern
 #139 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@array@"
 #140 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@array@"
 #141 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@array@"
@@ -151,20 +151,20 @@
 #151 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@array@"
 #152 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@array@"
 #153 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@array@"
-#154 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
-#155 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#154 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(1)" with "@array@" pattern
+#155 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(1)" does not match "@array@".
 #156 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@array@"
 #157 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "Array(1)" with "@array@" pattern
 #158 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "Array(1)" with "@array@" pattern
 #159 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: array "Array(1)" is not a valid string.
-#160 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
-#161 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: array "Array(1)" is not a valid string.
+#160 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(1)" with "@array@" pattern
+#161 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: array "Array(1)" is not a valid string.
 #162 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(1)" with "@array@" pattern
-#163 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
-#164 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#163 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Array(5)"
+#164 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(5)" with "Array(5)" pattern
 #165 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
-#166 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
-#167 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#166 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Array(5)"
+#167 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(5)" with "Array(5)" pattern
 #168 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
 #169 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
 #170 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
@@ -177,16 +177,16 @@
 #177 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
 #178 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
 #179 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
-#180 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
-#181 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#180 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(5)" with "Array(5)" pattern
+#181 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(1)" does not match "@array@".
 #182 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
-#183 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
-#184 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
-#185 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
-#186 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "132" with "@integer@" pattern
+#183 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(5)" with "Array(5)" pattern
+#184 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: "Array(1)" does not match "@array@".
+#185 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@integer@"
+#186 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "132" with "@integer@" pattern
 #187 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
-#188 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
-#189 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "132" with "@integer@" pattern
+#188 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@integer@"
+#189 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "132" with "@integer@" pattern
 #190 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
 #191 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
 #192 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
@@ -194,13 +194,13 @@
 #194 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
 #195 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "132" with "@integer@" pattern
 #196 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "132" with "@integer@" pattern
-#197 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "132" with "@integer@" pattern
-#198 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "132" with "@integer@" pattern
-#199 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Michał"
-#200 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Michał" with "Michał" pattern
+#197 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "132" with "@integer@" pattern
+#198 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "132" with "@integer@" pattern
+#199 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Michał"
+#200 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Michał" with "Michał" pattern
 #201 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Michał"
-#202 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Michał"
-#203 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Michał" with "Michał" pattern
+#202 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Michał"
+#203 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Michał" with "Michał" pattern
 #204 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Michał"
 #205 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Michał"
 #206 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Michał"
@@ -212,13 +212,13 @@
 #212 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Michał"
 #213 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Michał" with "Michał" pattern
 #214 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Michał" with "Michał" pattern
-#215 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Michał" with "Michał" pattern
-#216 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Michał" with "Michał" pattern
-#217 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Dąbrowski"
-#218 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#215 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Michał" with "Michał" pattern
+#216 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Michał" with "Michał" pattern
+#217 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Dąbrowski"
+#218 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Dąbrowski" with "Dąbrowski" pattern
 #219 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Dąbrowski"
-#220 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Dąbrowski"
-#221 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#220 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Dąbrowski"
+#221 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Dąbrowski" with "Dąbrowski" pattern
 #222 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Dąbrowski"
 #223 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Dąbrowski"
 #224 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Dąbrowski"
@@ -230,24 +230,24 @@
 #230 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Dąbrowski"
 #231 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
 #232 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#233 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#234 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#235 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "expr(value == false)"
-#236 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "false" with "expr(value == false)" pattern
+#233 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#234 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#235 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "expr(value == false)"
+#236 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "false" with "expr(value == false)" pattern
 #237 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "expr(value == false)"
-#238 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "expr(value == false)"
-#239 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "false" with "expr(value == false)" pattern
+#238 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "expr(value == false)"
+#239 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "false" with "expr(value == false)" pattern
 #240 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "expr(value == false)"
 #241 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can match pattern "expr(value == false)"
 #242 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher matching value "false" with "expr(value == false)" pattern
 #243 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher successfully matched value "false" with "expr(value == false)" pattern
-#244 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "false" with "expr(value == false)" pattern
-#245 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "false" with "expr(value == false)" pattern
-#246 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
-#247 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#244 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "false" with "expr(value == false)" pattern
+#245 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "false" with "expr(value == false)" pattern
+#246 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@array@"
+#247 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(1)" with "@array@" pattern
 #248 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@array@"
-#249 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
-#250 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#249 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@array@"
+#250 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(1)" with "@array@" pattern
 #251 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@array@"
 #252 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@array@"
 #253 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@array@"
@@ -263,42 +263,42 @@
 #263 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@array@"
 #264 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@array@"
 #265 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@array@"
-#266 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
-#267 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#266 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(1)" with "@array@" pattern
+#267 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(1)" does not match "@array@".
 #268 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@array@"
 #269 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "Array(1)" with "@array@" pattern
 #270 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "Array(1)" with "@array@" pattern
 #271 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: array "Array(1)" is not a valid string.
-#272 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
-#273 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: array "Array(1)" is not a valid string.
+#272 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(1)" with "@array@" pattern
+#273 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: array "Array(1)" is not a valid string.
 #274 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(1)" with "@array@" pattern
-#275 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
-#276 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#275 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@string@"
+#276 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
 #277 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@string@"
-#278 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
-#279 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#278 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@string@"
+#279 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
 #280 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
 #281 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
 #282 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
 #283 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
 #284 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
 #285 Matcher Coduo\PHPMatcher\Matcher\StringMatcher successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
-#286 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
-#287 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
-#288 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
-#289 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#286 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#287 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#288 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@string@"
+#289 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
 #290 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@string@"
-#291 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
-#292 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#291 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@string@"
+#292 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
 #293 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
 #294 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
 #295 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
 #296 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
 #297 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
 #298 Matcher Coduo\PHPMatcher\Matcher\StringMatcher successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
-#299 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
-#300 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#299 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#300 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
 #301 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(3)" with "Array(3)" pattern
 #302 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#303 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#303 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
 #304 Matcher Coduo\PHPMatcher\Matcher successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern

--- a/tests/BacktraceTest/succeed_complex_matching_expected_trace.txt
+++ b/tests/BacktraceTest/succeed_complex_matching_expected_trace.txt
@@ -1,0 +1,304 @@
+#1 Matcher Coduo\PHPMatcher\Matcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#5 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#6 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#7 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#8 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#9 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#10 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#11 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#12 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#13 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#14 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#15 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#16 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#17 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#18 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#19 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#20 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#21 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#22 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher can match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#23 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher matching value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#24 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher matching value "Array(3)" with "Array(3)" pattern
+#25 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(2)"
+#26 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(2)" with "Array(2)" pattern
+#27 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(2)"
+#28 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(2)"
+#29 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(2)" with "Array(2)" pattern
+#30 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(2)"
+#31 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(2)"
+#32 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(2)"
+#33 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Array(2)"
+#34 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Array(2)"
+#35 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Array(2)"
+#36 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Array(2)"
+#37 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Array(2)"
+#38 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can't match pattern "Array(2)"
+#39 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(2)"
+#40 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(2)"
+#41 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(2)"
+#42 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(2)" with "Array(2)" pattern
+#43 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#44 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(2)"
+#45 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(2)" with "Array(2)" pattern
+#46 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#47 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
+#48 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#49 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
+#50 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
+#51 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#52 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
+#53 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
+#54 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
+#55 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Array(5)"
+#56 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Array(5)"
+#57 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Array(5)"
+#58 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Array(5)"
+#59 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Array(5)"
+#60 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can't match pattern "Array(5)"
+#61 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
+#62 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
+#63 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
+#64 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
+#65 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#66 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
+#67 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
+#68 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" does not match "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}".
+#69 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
+#70 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "131" with "@integer@" pattern
+#71 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
+#72 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
+#73 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "131" with "@integer@" pattern
+#74 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
+#75 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
+#76 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
+#77 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@integer@"
+#78 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
+#79 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "131" with "@integer@" pattern
+#80 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "131" with "@integer@" pattern
+#81 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "131" with "@integer@" pattern
+#82 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "131" with "@integer@" pattern
+#83 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Norbert"
+#84 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Norbert" with "Norbert" pattern
+#85 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Norbert"
+#86 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Norbert"
+#87 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Norbert" with "Norbert" pattern
+#88 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Norbert"
+#89 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Norbert"
+#90 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Norbert"
+#91 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Norbert"
+#92 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Norbert"
+#93 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Norbert"
+#94 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Norbert"
+#95 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Norbert"
+#96 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Norbert"
+#97 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Norbert" with "Norbert" pattern
+#98 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Norbert" with "Norbert" pattern
+#99 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Norbert" with "Norbert" pattern
+#100 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Norbert" with "Norbert" pattern
+#101 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Orzechowicz"
+#102 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#103 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Orzechowicz"
+#104 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Orzechowicz"
+#105 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#106 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Orzechowicz"
+#107 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Orzechowicz"
+#108 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Orzechowicz"
+#109 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Orzechowicz"
+#110 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Orzechowicz"
+#111 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Orzechowicz"
+#112 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Orzechowicz"
+#113 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Orzechowicz"
+#114 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Orzechowicz"
+#115 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
+#116 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#117 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#118 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Orzechowicz" with "Orzechowicz" pattern
+#119 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@boolean@"
+#120 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "true" with "@boolean@" pattern
+#121 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@boolean@"
+#122 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@boolean@"
+#123 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "true" with "@boolean@" pattern
+#124 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@boolean@"
+#125 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@boolean@"
+#126 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@boolean@"
+#127 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@boolean@"
+#128 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@boolean@"
+#129 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can match pattern "@boolean@"
+#130 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher matching value "true" with "@boolean@" pattern
+#131 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher successfully matched value "true" with "@boolean@" pattern
+#132 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "true" with "@boolean@" pattern
+#133 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "true" with "@boolean@" pattern
+#134 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
+#135 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#136 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@array@"
+#137 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
+#138 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#139 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@array@"
+#140 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@array@"
+#141 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@array@"
+#142 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@array@"
+#143 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@array@"
+#144 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "@array@"
+#145 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "@array@"
+#146 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "@array@"
+#147 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "@array@"
+#148 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Array(1)" with "@array@" pattern
+#149 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "Array(1)" with "@array@" pattern
+#150 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "Array(1)" does not match "@array@".
+#151 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@array@"
+#152 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@array@"
+#153 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@array@"
+#154 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
+#155 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#156 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@array@"
+#157 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "Array(1)" with "@array@" pattern
+#158 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "Array(1)" with "@array@" pattern
+#159 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: array "Array(1)" is not a valid string.
+#160 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
+#161 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: array "Array(1)" is not a valid string.
+#162 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(1)" with "@array@" pattern
+#163 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
+#164 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#165 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
+#166 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Array(5)"
+#167 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(5)" with "Array(5)" pattern
+#168 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
+#169 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
+#170 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
+#171 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Array(5)"
+#172 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Array(5)"
+#173 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Array(5)"
+#174 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Array(5)"
+#175 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Array(5)"
+#176 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can't match pattern "Array(5)"
+#177 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
+#178 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
+#179 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
+#180 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
+#181 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#182 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
+#183 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(5)" with "Array(5)" pattern
+#184 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#185 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
+#186 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "132" with "@integer@" pattern
+#187 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
+#188 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@integer@"
+#189 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "132" with "@integer@" pattern
+#190 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
+#191 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
+#192 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
+#193 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@integer@"
+#194 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
+#195 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "132" with "@integer@" pattern
+#196 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "132" with "@integer@" pattern
+#197 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "132" with "@integer@" pattern
+#198 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "132" with "@integer@" pattern
+#199 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Michał"
+#200 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Michał" with "Michał" pattern
+#201 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Michał"
+#202 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Michał"
+#203 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Michał" with "Michał" pattern
+#204 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Michał"
+#205 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Michał"
+#206 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Michał"
+#207 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Michał"
+#208 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Michał"
+#209 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Michał"
+#210 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Michał"
+#211 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Michał"
+#212 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Michał"
+#213 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Michał" with "Michał" pattern
+#214 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Michał" with "Michał" pattern
+#215 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Michał" with "Michał" pattern
+#216 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Michał" with "Michał" pattern
+#217 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Dąbrowski"
+#218 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#219 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Dąbrowski"
+#220 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "Dąbrowski"
+#221 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#222 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Dąbrowski"
+#223 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Dąbrowski"
+#224 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Dąbrowski"
+#225 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Dąbrowski"
+#226 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Dąbrowski"
+#227 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Dąbrowski"
+#228 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Dąbrowski"
+#229 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Dąbrowski"
+#230 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Dąbrowski"
+#231 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
+#232 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#233 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#234 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "Dąbrowski" with "Dąbrowski" pattern
+#235 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "expr(value == false)"
+#236 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "false" with "expr(value == false)" pattern
+#237 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "expr(value == false)"
+#238 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "expr(value == false)"
+#239 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "false" with "expr(value == false)" pattern
+#240 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "expr(value == false)"
+#241 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can match pattern "expr(value == false)"
+#242 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher matching value "false" with "expr(value == false)" pattern
+#243 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher successfully matched value "false" with "expr(value == false)" pattern
+#244 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "false" with "expr(value == false)" pattern
+#245 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "false" with "expr(value == false)" pattern
+#246 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
+#247 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#248 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@array@"
+#249 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@array@"
+#250 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "Array(1)" with "@array@" pattern
+#251 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@array@"
+#252 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@array@"
+#253 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@array@"
+#254 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@array@"
+#255 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@array@"
+#256 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "@array@"
+#257 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "@array@"
+#258 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "@array@"
+#259 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "@array@"
+#260 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Array(1)" with "@array@" pattern
+#261 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "Array(1)" with "@array@" pattern
+#262 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "Array(1)" does not match "@array@".
+#263 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@array@"
+#264 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@array@"
+#265 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@array@"
+#266 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
+#267 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: "Array(1)" does not match "@array@".
+#268 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@array@"
+#269 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "Array(1)" with "@array@" pattern
+#270 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "Array(1)" with "@array@" pattern
+#271 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: array "Array(1)" is not a valid string.
+#272 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher failed to match value "Array(1)" with "@array@" pattern
+#273 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher error: array "Array(1)" is not a valid string.
+#274 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(1)" with "@array@" pattern
+#275 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
+#276 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#277 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@string@"
+#278 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
+#279 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#280 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
+#281 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
+#282 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
+#283 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
+#284 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#285 Matcher Coduo\PHPMatcher\Matcher\StringMatcher successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#286 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#287 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
+#288 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
+#289 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#290 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@string@"
+#291 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher can match pattern "@string@"
+#292 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#293 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
+#294 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
+#295 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
+#296 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
+#297 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#298 Matcher Coduo\PHPMatcher\Matcher\StringMatcher successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#299 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#300 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
+#301 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(3)" with "Array(3)" pattern
+#302 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#303 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#304 Matcher Coduo\PHPMatcher\Matcher successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":["ROLE_DEVELOPER"]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern

--- a/tests/Matcher/ArrayMatcherTest.php
+++ b/tests/Matcher/ArrayMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Parser;
@@ -20,18 +21,21 @@ class ArrayMatcherTest extends TestCase
     {
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
         $this->matcher = new Matcher\ArrayMatcher(
-            new Matcher\ChainMatcher([
-                new Matcher\CallbackMatcher(),
-                new Matcher\ExpressionMatcher(),
-                new Matcher\NullMatcher(),
-                new Matcher\StringMatcher($parser),
-                new Matcher\IntegerMatcher($parser),
-                new Matcher\BooleanMatcher($parser),
-                new Matcher\DoubleMatcher($parser),
-                new Matcher\NumberMatcher($parser),
-                new Matcher\ScalarMatcher(),
-                new Matcher\WildcardMatcher(),
-            ]),
+            new Matcher\ChainMatcher(
+                $backtrace = new Backtrace(),
+                [
+                    new Matcher\CallbackMatcher($backtrace),
+                    new Matcher\ExpressionMatcher($backtrace),
+                    new Matcher\NullMatcher($backtrace),
+                    new Matcher\StringMatcher($backtrace, $parser),
+                    new Matcher\IntegerMatcher($backtrace, $parser),
+                    new Matcher\BooleanMatcher($backtrace, $parser),
+                    new Matcher\DoubleMatcher($backtrace, $parser),
+                    new Matcher\NumberMatcher($backtrace, $parser),
+                    new Matcher\ScalarMatcher($backtrace),
+                    new Matcher\WildcardMatcher($backtrace),
+                ]
+            ),
             $parser
         );
     }
@@ -55,8 +59,8 @@ class ArrayMatcherTest extends TestCase
     public function test_negative_match_when_cant_find_matcher_that_can_match_array_element()
     {
         $matcher = new Matcher\ArrayMatcher(
-            new Matcher\ChainMatcher([
-                new Matcher\WildcardMatcher()
+            new Matcher\ChainMatcher($backtrace = new Backtrace(), [
+                new Matcher\WildcardMatcher($backtrace)
             ]),
             $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer())
         );

--- a/tests/Matcher/ArrayMatcherTest.php
+++ b/tests/Matcher/ArrayMatcherTest.php
@@ -36,6 +36,7 @@ class ArrayMatcherTest extends TestCase
                     new Matcher\WildcardMatcher($backtrace),
                 ]
             ),
+            $backtrace,
             $parser
         );
     }
@@ -62,6 +63,7 @@ class ArrayMatcherTest extends TestCase
             new Matcher\ChainMatcher($backtrace = new Backtrace(), [
                 new Matcher\WildcardMatcher($backtrace)
             ]),
+            $backtrace,
             $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer())
         );
 

--- a/tests/Matcher/ArrayMatcherTest.php
+++ b/tests/Matcher/ArrayMatcherTest.php
@@ -22,6 +22,7 @@ class ArrayMatcherTest extends TestCase
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
         $this->matcher = new Matcher\ArrayMatcher(
             new Matcher\ChainMatcher(
+                self::class,
                 $backtrace = new Backtrace(),
                 [
                     new Matcher\CallbackMatcher($backtrace),
@@ -60,9 +61,13 @@ class ArrayMatcherTest extends TestCase
     public function test_negative_match_when_cant_find_matcher_that_can_match_array_element()
     {
         $matcher = new Matcher\ArrayMatcher(
-            new Matcher\ChainMatcher($backtrace = new Backtrace(), [
-                new Matcher\WildcardMatcher($backtrace)
-            ]),
+            new Matcher\ChainMatcher(
+                self::class,
+                $backtrace = new Backtrace(),
+                [
+                    new Matcher\WildcardMatcher($backtrace)
+                ]
+            ),
             $backtrace,
             $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer())
         );

--- a/tests/Matcher/BooleanMatcherTest.php
+++ b/tests/Matcher/BooleanMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Parser;
 use Coduo\PHPMatcher\Matcher\BooleanMatcher;
@@ -18,7 +19,7 @@ class BooleanMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $this->matcher = new BooleanMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new BooleanMatcher(new Backtrace(), new Parser(new Lexer(), new Parser\ExpanderInitializer()));
     }
 
     /**

--- a/tests/Matcher/CallbackMatcherTest.php
+++ b/tests/Matcher/CallbackMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Matcher\CallbackMatcher;
 use PHPUnit\Framework\TestCase;
 
@@ -11,7 +12,7 @@ class CallbackMatcherTest extends TestCase
 {
     public function test_positive_can_match()
     {
-        $matcher = new CallbackMatcher();
+        $matcher = new CallbackMatcher(new Backtrace());
         $this->assertTrue($matcher->canMatch(function () {
             return true;
         }));
@@ -19,14 +20,14 @@ class CallbackMatcherTest extends TestCase
 
     public function test_negative_can_match()
     {
-        $matcher = new CallbackMatcher();
+        $matcher = new CallbackMatcher(new Backtrace());
         $this->assertFalse($matcher->canMatch(new \DateTime()));
         $this->assertFalse($matcher->canMatch('SIN'));
     }
 
     public function test_positive_matches()
     {
-        $matcher = new CallbackMatcher();
+        $matcher = new CallbackMatcher(new Backtrace());
         $this->assertTrue($matcher->match(2, function ($value) {
             return true;
         }));
@@ -37,7 +38,7 @@ class CallbackMatcherTest extends TestCase
 
     public function test_negative_matches()
     {
-        $matcher = new CallbackMatcher();
+        $matcher = new CallbackMatcher(new Backtrace());
         $this->assertFalse($matcher->match(2, function ($value) {
             return false;
         }));

--- a/tests/Matcher/ChainMatcherTest.php
+++ b/tests/Matcher/ChainMatcherTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Matcher\ArrayMatcher;
 use Coduo\PHPMatcher\Matcher\ChainMatcher;
+use Coduo\PHPMatcher\Matcher\ValueMatcher;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ChainMatcherTest extends TestCase
@@ -16,21 +19,21 @@ class ChainMatcherTest extends TestCase
     private $matcher;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var MockObject
      */
     private $firstMatcher;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var MockObject
      */
     private $secondMatcher;
 
     public function setUp() : void
     {
-        $this->firstMatcher = $this->createMock('Coduo\PHPMatcher\Matcher\ValueMatcher');
-        $this->secondMatcher = $this->createMock('Coduo\PHPMatcher\Matcher\ValueMatcher');
+        $this->firstMatcher = $this->createMock(ValueMatcher::class);
+        $this->secondMatcher = $this->createMock(ValueMatcher::class);
 
-        $this->matcher = new ChainMatcher([
+        $this->matcher = new ChainMatcher(new Backtrace(), [
             $this->firstMatcher,
             $this->secondMatcher
         ]);

--- a/tests/Matcher/ChainMatcherTest.php
+++ b/tests/Matcher/ChainMatcherTest.php
@@ -33,10 +33,14 @@ class ChainMatcherTest extends TestCase
         $this->firstMatcher = $this->createMock(ValueMatcher::class);
         $this->secondMatcher = $this->createMock(ValueMatcher::class);
 
-        $this->matcher = new ChainMatcher(new Backtrace(), [
-            $this->firstMatcher,
-            $this->secondMatcher
-        ]);
+        $this->matcher = new ChainMatcher(
+            self::class,
+            new Backtrace(),
+            [
+                $this->firstMatcher,
+                $this->secondMatcher
+            ]
+        );
     }
 
     public function test_only_one_matcher_can_match_but_none_matchers_match()

--- a/tests/Matcher/DoubleMatcherTest.php
+++ b/tests/Matcher/DoubleMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\DoubleMatcher;
 use Coduo\PHPMatcher\Parser;
@@ -18,7 +19,7 @@ class DoubleMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $this->matcher = new DoubleMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new DoubleMatcher(new Backtrace(), new Parser(new Lexer(), new Parser\ExpanderInitializer()));
     }
 
     /**

--- a/tests/Matcher/ExpressionMatcherTest.php
+++ b/tests/Matcher/ExpressionMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Matcher\ExpressionMatcher;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_positive_can_matches($pattern)
     {
-        $matcher = new ExpressionMatcher();
+        $matcher = new ExpressionMatcher(new Backtrace());
         $this->assertTrue($matcher->canMatch($pattern));
     }
 
@@ -23,7 +24,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_negative_can_matches($pattern)
     {
-        $matcher = new ExpressionMatcher();
+        $matcher = new ExpressionMatcher(new Backtrace());
         $this->assertFalse($matcher->canMatch($pattern));
     }
 
@@ -32,7 +33,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_positive_match($value, $pattern)
     {
-        $matcher = new ExpressionMatcher();
+        $matcher = new ExpressionMatcher(new Backtrace());
         $this->assertTrue($matcher->match($value, $pattern));
     }
 
@@ -41,7 +42,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_negative_match($value, $pattern)
     {
-        $matcher = new ExpressionMatcher();
+        $matcher = new ExpressionMatcher(new Backtrace());
         $this->assertFalse($matcher->match($value, $pattern));
     }
 
@@ -50,7 +51,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_negative_match_description($value, $pattern, $error)
     {
-        $matcher = new ExpressionMatcher();
+        $matcher = new ExpressionMatcher(new Backtrace());
         $matcher->match($value, $pattern);
         $this->assertEquals($error, $matcher->getError());
     }
@@ -60,7 +61,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_positive_regex_matches($value, $pattern)
     {
-        $matcher = new ExpressionMatcher();
+        $matcher = new ExpressionMatcher(new Backtrace());
         $this->assertTrue($matcher->match($value, $pattern));
     }
 
@@ -69,7 +70,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_negative_regex_matches($value, $pattern)
     {
-        $matcher = new ExpressionMatcher();
+        $matcher = new ExpressionMatcher(new Backtrace());
         $this->assertFalse($matcher->match($value, $pattern));
     }
 

--- a/tests/Matcher/IntegerMatcherTest.php
+++ b/tests/Matcher/IntegerMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\IntegerMatcher;
 use Coduo\PHPMatcher\Parser;
@@ -18,7 +19,7 @@ class IntegerMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $this->matcher = new IntegerMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new IntegerMatcher(new Backtrace(), new Parser(new Lexer(), new Parser\ExpanderInitializer()));
     }
 
     /**

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -36,7 +36,8 @@ class JsonMatcherTest extends TestCase
             ]
         );
         $this->matcher = new Matcher\JsonMatcher(
-            new Matcher\ArrayMatcher($scalarMatchers, $parser)
+            new Matcher\ArrayMatcher($scalarMatchers, $backtrace, $parser),
+            $backtrace
         );
     }
 

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Parser;
@@ -19,18 +20,21 @@ class JsonMatcherTest extends TestCase
     public function setUp() : void
     {
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
-        $scalarMatchers = new Matcher\ChainMatcher([
-            new Matcher\CallbackMatcher(),
-            new Matcher\ExpressionMatcher(),
-            new Matcher\NullMatcher(),
-            new Matcher\StringMatcher($parser),
-            new Matcher\IntegerMatcher($parser),
-            new Matcher\BooleanMatcher($parser),
-            new Matcher\DoubleMatcher($parser),
-            new Matcher\NumberMatcher($parser),
-            new Matcher\ScalarMatcher(),
-            new Matcher\WildcardMatcher(),
-        ]);
+        $scalarMatchers = new Matcher\ChainMatcher(
+            $backtrace = new Backtrace(),
+            [
+                new Matcher\CallbackMatcher($backtrace),
+                new Matcher\ExpressionMatcher($backtrace),
+                new Matcher\NullMatcher($backtrace),
+                new Matcher\StringMatcher($backtrace, $parser),
+                new Matcher\IntegerMatcher($backtrace, $parser),
+                new Matcher\BooleanMatcher($backtrace, $parser),
+                new Matcher\DoubleMatcher($backtrace, $parser),
+                new Matcher\NumberMatcher($backtrace, $parser),
+                new Matcher\ScalarMatcher($backtrace),
+                new Matcher\WildcardMatcher($backtrace),
+            ]
+        );
         $this->matcher = new Matcher\JsonMatcher(
             new Matcher\ArrayMatcher($scalarMatchers, $parser)
         );

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -21,6 +21,7 @@ class JsonMatcherTest extends TestCase
     {
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
         $scalarMatchers = new Matcher\ChainMatcher(
+            self::class,
             $backtrace = new Backtrace(),
             [
                 new Matcher\CallbackMatcher($backtrace),

--- a/tests/Matcher/JsonObjectMatcherTest.php
+++ b/tests/Matcher/JsonObjectMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\JsonObjectMatcher;
 use Coduo\PHPMatcher\Parser;
@@ -18,7 +19,7 @@ final class JsonObjectMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $this->matcher = new JsonObjectMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new JsonObjectMatcher(new Backtrace(), new Parser(new Lexer(), new Parser\ExpanderInitializer()));
     }
 
     /**

--- a/tests/Matcher/NullMatcherTest.php
+++ b/tests/Matcher/NullMatcherTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
-use Coduo\PHPMatcher\Lexer;
-use Coduo\PHPMatcher\Parser;
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Matcher\NullMatcher;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +17,7 @@ class NullMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $this->matcher = new NullMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new NullMatcher(new Backtrace());
     }
 
     /**

--- a/tests/Matcher/NumberMatcherTest.php
+++ b/tests/Matcher/NumberMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Parser;
 use Coduo\PHPMatcher\Matcher\NumberMatcher;
@@ -18,7 +19,7 @@ class NumberMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $this->matcher = new NumberMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new NumberMatcher(new Backtrace(), new Parser(new Lexer(), new Parser\ExpanderInitializer()));
     }
 
     /**

--- a/tests/Matcher/ScalarMatcherTest.php
+++ b/tests/Matcher/ScalarMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Matcher\ScalarMatcher;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_positive_can_matches($pattern)
     {
-        $matcher = new ScalarMatcher();
+        $matcher = new ScalarMatcher(new Backtrace());
         $this->assertTrue($matcher->canMatch($pattern));
     }
 
@@ -23,7 +24,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_negative_can_matches($pattern)
     {
-        $matcher = new ScalarMatcher();
+        $matcher = new ScalarMatcher(new Backtrace());
         $this->assertFalse($matcher->canMatch($pattern));
     }
 
@@ -32,7 +33,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_positive_matches($value, $pattern)
     {
-        $matcher = new ScalarMatcher();
+        $matcher = new ScalarMatcher(new Backtrace());
         $this->assertTrue($matcher->match($value, $pattern));
     }
 
@@ -41,7 +42,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_negative_matches($value, $pattern)
     {
-        $matcher = new ScalarMatcher();
+        $matcher = new ScalarMatcher(new Backtrace());
         $this->assertFalse($matcher->match($value, $pattern));
     }
 
@@ -50,7 +51,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_negative_match_description($value, $pattern, $error)
     {
-        $matcher = new ScalarMatcher();
+        $matcher = new ScalarMatcher(new Backtrace());
         $matcher->match($value, $pattern);
         $this->assertEquals($error, $matcher->getError());
     }

--- a/tests/Matcher/StringMatcherTest.php
+++ b/tests/Matcher/StringMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher\StringMatcher;
 use Coduo\PHPMatcher\Parser;
@@ -18,8 +19,7 @@ class StringMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
-        $this->matcher = new StringMatcher($parser);
+        $this->matcher = new StringMatcher(new Backtrace(), new Parser(new Lexer(), new Parser\ExpanderInitializer()));
     }
     /**
      * @dataProvider positiveCanMatchData

--- a/tests/Matcher/TextMatcherTest.php
+++ b/tests/Matcher/TextMatcherTest.php
@@ -40,7 +40,7 @@ class TextMatcherTest extends TestCase
                 $backtrace,
                 [
                     $scalarMatchers,
-                    new Matcher\ArrayMatcher($scalarMatchers, $parser)
+                    new Matcher\ArrayMatcher($scalarMatchers, $backtrace, $parser)
                 ]
             ),
             $backtrace,

--- a/tests/Matcher/TextMatcherTest.php
+++ b/tests/Matcher/TextMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Parser;
@@ -19,23 +20,30 @@ class TextMatcherTest extends TestCase
     public function setUp() : void
     {
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
-        $scalarMatchers = new Matcher\ChainMatcher([
-            new Matcher\CallbackMatcher(),
-            new Matcher\ExpressionMatcher(),
-            new Matcher\NullMatcher(),
-            new Matcher\StringMatcher($parser),
-            new Matcher\IntegerMatcher($parser),
-            new Matcher\BooleanMatcher($parser),
-            new Matcher\DoubleMatcher($parser),
-            new Matcher\NumberMatcher($parser),
-            new Matcher\ScalarMatcher(),
-            new Matcher\WildcardMatcher(),
-        ]);
+        $scalarMatchers = new Matcher\ChainMatcher(
+            $backtrace = new Backtrace(),
+            [
+                new Matcher\CallbackMatcher($backtrace),
+                new Matcher\ExpressionMatcher($backtrace),
+                new Matcher\NullMatcher($backtrace),
+                new Matcher\StringMatcher($backtrace, $parser),
+                new Matcher\IntegerMatcher($backtrace, $parser),
+                new Matcher\BooleanMatcher($backtrace, $parser),
+                new Matcher\DoubleMatcher($backtrace, $parser),
+                new Matcher\NumberMatcher($backtrace, $parser),
+                new Matcher\ScalarMatcher($backtrace),
+                new Matcher\WildcardMatcher($backtrace),
+            ]
+        );
         $this->matcher = new Matcher\TextMatcher(
-            new Matcher\ChainMatcher([
-                $scalarMatchers,
-                new Matcher\ArrayMatcher($scalarMatchers, $parser)
-            ]),
+            new Matcher\ChainMatcher(
+                $backtrace,
+                [
+                    $scalarMatchers,
+                    new Matcher\ArrayMatcher($scalarMatchers, $parser)
+                ]
+            ),
+            $backtrace,
             $parser
         );
     }

--- a/tests/Matcher/TextMatcherTest.php
+++ b/tests/Matcher/TextMatcherTest.php
@@ -21,6 +21,7 @@ class TextMatcherTest extends TestCase
     {
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
         $scalarMatchers = new Matcher\ChainMatcher(
+            self::class,
             $backtrace = new Backtrace(),
             [
                 new Matcher\CallbackMatcher($backtrace),
@@ -37,6 +38,7 @@ class TextMatcherTest extends TestCase
         );
         $this->matcher = new Matcher\TextMatcher(
             new Matcher\ChainMatcher(
+                self::class,
                 $backtrace,
                 [
                     $scalarMatchers,

--- a/tests/Matcher/UuidMatcherTest.php
+++ b/tests/Matcher/UuidMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Parser;
 use Coduo\PHPMatcher\Matcher\UuidMatcher;
@@ -18,7 +19,7 @@ class UuidMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $this->matcher = new UuidMatcher(new Parser(new Lexer(), new Parser\ExpanderInitializer()));
+        $this->matcher = new UuidMatcher(new Backtrace(), new Parser(new Lexer(), new Parser\ExpanderInitializer()));
     }
     /**
      * @dataProvider positiveCanMatchData

--- a/tests/Matcher/WildcardMatcherTest.php
+++ b/tests/Matcher/WildcardMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Matcher\WildcardMatcher;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,7 @@ class WildcardMatcherTest extends TestCase
      */
     public function test_positive_match($pattern)
     {
-        $matcher = new WildcardMatcher();
+        $matcher = new WildcardMatcher(new Backtrace());
         $this->assertTrue($matcher->match('*', $pattern));
     }
 
@@ -24,13 +25,13 @@ class WildcardMatcherTest extends TestCase
      */
     public function test_positive_can_match($pattern)
     {
-        $matcher = new WildcardMatcher();
+        $matcher = new WildcardMatcher(new Backtrace());
         $this->assertTrue($matcher->canMatch($pattern));
     }
 
     public function test_negative_can_match()
     {
-        $matcher = new WildcardMatcher();
+        $matcher = new WildcardMatcher(new Backtrace());
         $this->assertFalse($matcher->canMatch('*'));
     }
 

--- a/tests/Matcher/XmlMatcherTest.php
+++ b/tests/Matcher/XmlMatcherTest.php
@@ -21,6 +21,7 @@ class XmlMatcherTest extends TestCase
     {
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
         $scalarMatchers = new Matcher\ChainMatcher(
+            self::class,
             $backtrace = new Backtrace(),
             [
                 new Matcher\CallbackMatcher($backtrace),

--- a/tests/Matcher/XmlMatcherTest.php
+++ b/tests/Matcher/XmlMatcherTest.php
@@ -37,7 +37,8 @@ class XmlMatcherTest extends TestCase
         );
 
         $this->matcher = new Matcher\XmlMatcher(
-            new Matcher\ArrayMatcher($scalarMatchers, $parser)
+            new Matcher\ArrayMatcher($scalarMatchers, $backtrace, $parser),
+            $backtrace
         );
     }
 

--- a/tests/Matcher/XmlMatcherTest.php
+++ b/tests/Matcher/XmlMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\Parser;
@@ -19,18 +20,21 @@ class XmlMatcherTest extends TestCase
     public function setUp() : void
     {
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer());
-        $scalarMatchers = new Matcher\ChainMatcher([
-            new Matcher\CallbackMatcher(),
-            new Matcher\ExpressionMatcher(),
-            new Matcher\NullMatcher(),
-            new Matcher\StringMatcher($parser),
-            new Matcher\IntegerMatcher($parser),
-            new Matcher\BooleanMatcher($parser),
-            new Matcher\DoubleMatcher($parser),
-            new Matcher\NumberMatcher($parser),
-            new Matcher\ScalarMatcher(),
-            new Matcher\WildcardMatcher(),
-        ]);
+        $scalarMatchers = new Matcher\ChainMatcher(
+            $backtrace = new Backtrace(),
+            [
+                new Matcher\CallbackMatcher($backtrace),
+                new Matcher\ExpressionMatcher($backtrace),
+                new Matcher\NullMatcher($backtrace),
+                new Matcher\StringMatcher($backtrace, $parser),
+                new Matcher\IntegerMatcher($backtrace, $parser),
+                new Matcher\BooleanMatcher($backtrace, $parser),
+                new Matcher\DoubleMatcher($backtrace, $parser),
+                new Matcher\NumberMatcher($backtrace, $parser),
+                new Matcher\ScalarMatcher($backtrace),
+                new Matcher\WildcardMatcher($backtrace),
+            ]
+        );
 
         $this->matcher = new Matcher\XmlMatcher(
             new Matcher\ArrayMatcher($scalarMatchers, $parser)

--- a/tests/PHPUnit/PHPMatcherConstraintTest.php
+++ b/tests/PHPUnit/PHPMatcherConstraintTest.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Tests\PHPUnit;
 
 use Coduo\PHPMatcher\PHPUnit\PHPMatcherConstraint;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
 
 class PHPMatcherConstraintTest extends TestCase
 {
     public function test_it_is_a_phpunit_constraint()
     {
-        $this->assertInstanceOf('PHPUnit\Framework\Constraint\Constraint', new PHPMatcherConstraint('@string@'));
+        $this->assertInstanceOf(Constraint::class, new PHPMatcherConstraint('@string@'));
     }
 
     public function test_it_returns_true_if_a_value_matches_the_pattern()
@@ -30,7 +32,7 @@ class PHPMatcherConstraintTest extends TestCase
 
     public function test_it_sets_a_failure_description_if_not_given()
     {
-        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that 42 matches the pattern');
 
         $constraint = new PHPMatcherConstraint('@string@');
@@ -40,7 +42,7 @@ class PHPMatcherConstraintTest extends TestCase
 
     public function test_it_sets_additional_failure_description()
     {
-        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('integer "42" is not a valid string');
 
         $constraint = new PHPMatcherConstraint('@string@');


### PR DESCRIPTION
Debugging php-matcher is not an easy task, especially when working with complex values/patterns. 
Backtrace should simplify this process, below example of backtrace for simple match:

```php
$matcher->match('100', '@string@')
echo (string) $matcher->backtrace();
```

```
#1 Matcher Coduo\PHPMatcher\Matcher matching value "100" with "@string@" pattern
#2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) matching value "100" with "@string@" pattern
#3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@string@"
#4 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "100" with "@string@" pattern
#5 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
#6 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
#7 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
#8 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
#9 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "100" with "@string@" pattern
#10 Matcher Coduo\PHPMatcher\Matcher\StringMatcher successfully matched value "100" with "@string@" pattern
#11 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "100" with "@string@" pattern
#12 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) successfully matched value "100" with "@string@" pattern
#13 Matcher Coduo\PHPMatcher\Matcher successfully matched value "100" with "@string@" pattern
```

More complex matchers will generate huge backtraces but when going through them step by step it's easy to track all mistakes. 