### PR TITLE
Correctly finds not existing keys when checking Array matcher pattern

### DIFF
--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -115,24 +115,22 @@ final class ArrayMatcher extends Matcher
 
     private function isPatternValid(array $pattern, array $values, string $parentPath) : bool
     {
-        if (\is_array($pattern)) {
-            $skipPattern = static::UNBOUNDED_PATTERN;
+        $skipPattern = static::UNBOUNDED_PATTERN;
 
-            $pattern = \array_filter(
-                $pattern,
-                function ($item) use ($skipPattern) {
-                    return $item !== $skipPattern;
-                }
-            );
-
-            $notExistingKeys = $this->findNotExistingKeys($pattern, $values);
-            if (\count($notExistingKeys) > 0) {
-                $keyNames = \array_keys($notExistingKeys);
-                $path = $this->formatFullPath($parentPath, $this->formatAccessPath($keyNames[0]));
-                $this->setMissingElementInError('value', $path);
-
-                return false;
+        $pattern = \array_filter(
+            $pattern,
+            function ($item) use ($skipPattern) {
+                return $item !== $skipPattern;
             }
+        );
+
+        $notExistingKeys = $this->findNotExistingKeys($pattern, $values);
+        if (\count($notExistingKeys) > 0) {
+            $keyNames = \array_keys($notExistingKeys);
+            $path = $this->formatFullPath($parentPath, $this->formatAccessPath($keyNames[0]));
+            $this->setMissingElementInError('value', $path);
+
+            return false;
         }
 
         return true;

--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -143,8 +143,9 @@ final class ArrayMatcher extends Matcher
         $notExistingKeys = \array_diff_key($pattern, $values);
 
         return \array_filter($notExistingKeys, function ($pattern) use ($values) {
+
             if (\is_array($pattern)) {
-                return !$this->match($values, $pattern);
+                return empty($pattern) || !$this->match($values, $pattern);
             }
 
             try {

--- a/src/Matcher/ArrayMatcher.php
+++ b/src/Matcher/ArrayMatcher.php
@@ -141,7 +141,6 @@ final class ArrayMatcher extends Matcher
         $notExistingKeys = \array_diff_key($pattern, $values);
 
         return \array_filter($notExistingKeys, function ($pattern) use ($values) {
-
             if (\is_array($pattern)) {
                 return empty($pattern) || !$this->match($values, $pattern);
             }

--- a/tests/Matcher/ArrayMatcherTest.php
+++ b/tests/Matcher/ArrayMatcherTest.php
@@ -233,6 +233,7 @@ class ArrayMatcherTest extends TestCase
             [[1], [2]],
             [['foo', 1, 3], ['foo', 2, 3]],
             [[], ['key' => []]],
+            [[], ['foo' => 'bar']],
             [[], ['foo' => ['bar' => []]]],
             'unbound array should match one or none elements' => [
                 [

--- a/tests/Matcher/ArrayMatcherTest.php
+++ b/tests/Matcher/ArrayMatcherTest.php
@@ -162,6 +162,7 @@ class ArrayMatcherTest extends TestCase
             [$simpleArr, $simpleArr],
             [$simpleArr, $simpleArrPattern],
             [[], []],
+            [[], ['@boolean@.optional()']],
             [['foo' => null], ['foo' => null]],
             [['foo' => null], ['foo' => '@null@']],
             [['key' => 'val'], ['key' => 'val']],
@@ -231,7 +232,8 @@ class ArrayMatcherTest extends TestCase
             [['key' => 'val'], ['key' => 'val2']],
             [[1], [2]],
             [['foo', 1, 3], ['foo', 2, 3]],
-            [[], ['foo' => 'bar']],
+            [[], ['key' => []]],
+            [[], ['foo' => ['bar' => []]]],
             'unbound array should match one or none elements' => [
                 [
                     'users' => [

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -365,6 +365,8 @@ XML;
             ['', '@string@.isEmpty()', true],
             [['foo', 'bar'], '@array@.inArray("bar")', true],
             [[], '@array@.isEmpty()', true],
+            [[], ['@string@'], false],
+            [[], ['@string@.optional()'], true],
             [['foo'], '@array@.isEmpty()', false],
             [[1, 2, 3], '@array@.count(3)', true],
             [[1, 2, 3], '@array@.count(4)', false],
@@ -383,6 +385,8 @@ XML;
             [[], ['unexistent_key' => '@text@.optional()'], true],
             [[], ['unexistent_key' => '@uuid@.optional()'], true],
             [[], ['unexistent_key' => '@xml@.optional()'], true],
+            [[], ['unexistent_key' => '@array@.optional()', 'unexistent_second_key' => '@string@.optional()'], true],
+            [[], ['unexistent_key' => '@array@.optional()', 'unexistent_second_key' => '@string@'], false],
             [['Norbert', 'Michał'], '@array@.repeat("@string@")', true],
         ];
     }


### PR DESCRIPTION
This should be treated as reopen of #163 where I was looking for a solution in the wrong place.
This PR is also a bugfix for version 3.0.0 so I need to create a new one from tag 3.0.0 instead of the master branch.