### PR TITLE
Replaced PHPMatcher facade with implementation that makes possible to access backtrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 Library created for testing all kinds of JSON/XML/TXT/Scalar values against patterns.
 
+API: 
+
 ```php
-PHPMatcher::match($value = '{"foo": "bar"}', $pattern = '{"foo": "@string@"}');
+PHPMatcher::match($value = '{"foo": "bar"}', $pattern = '{"foo": "@string@"}') : bool;
+PHPMatcher::backtrace() : Backtrace;
+PHPMatcher::error() : ?string;
 ```
 
 It was built to simplify API's functional testing.
@@ -31,32 +35,56 @@ composer require --dev "coduo/php-matcher"
 
 ## Basic usage
 
-### Using facade
+### Direct PHPMatcher usage
 
 ```php
 <?php
 
 use Coduo\PHPMatcher\PHPMatcher;
 
-if (!PHPMatcher::match("lorem ipsum dolor", "@string@", $error)) {
-    echo $error; // in case of error message is set on $error variable via reference
-}
+$matcher = new PHPMatcher();
+$match = $matcher->match("lorem ipsum dolor", "@string@");
 
+if (!$match) {
+    echo "Error: " . $matcher->error();
+    echo "Backtrace: \n";
+    echo (string) $matcher->backtrace();
+}
 ```
 
-### Using Factory
+### PHPUnit extending PHPMatcherTestCase
 
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPUnit\PHPMatcherTestCase;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+class MatcherTest extends PHPMatcherTestCase
+{
+    public function test_matcher_that_value_matches_pattern()
+    {
+        $this->assertMatchesPattern('{"name": "Norbert"}', '{"name": "@string@"}');
+    }
+}
+```
 
-$match = $matcher->match("lorem ipsum dolor", "@string@");
-// $match === true
-$matcher->getError(); // returns null or error message
+### PHPUnit using PHPMatcherAssertions trait
+
+```php
+<?php
+
+use Coduo\PHPMatcher\PHPUnit\PHPMatcherAssertions;
+use PHPUnit\Framework\TestCase;
+
+class MatcherTest extends TestCase
+{
+    use PHPMatcherAssertions;
+
+    public function test_matcher_that_value_matches_pattern()
+    {
+        $this->assertMatchesPattern('{"name": "Norbert"}', '{"name": "@string@"}');
+    }
+}
 ```
 
 ### Available patterns

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,26 @@
+# 3.x -> 4.0 
+
+Below you can find list of changes between 3.x and 4.0 versions of PHPMatcher.
+
+### Creating Matcher
+
+```diff
+-$factory = new MatcherFactory();
+-$this->matcher = $factory->createMatcher();
+```
+
+```diff
++$this->matcher = new PHPMatcher();
+```
+
+### Simple Matching
+
+```diff
+-PHPMatcher::match($value, $pattern, $error)
+```
+
+```diff
++$matcher = new PHPMatcher();
++$matcher->match($value, $pattern);
++echo $matcher->error();
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,26 +1,24 @@
 # 3.x -> 4.0 
 
-Below you can find list of changes between 3.x and 4.0 versions of PHPMatcher.
+Below you can find list of changes between `3.x` and `4.0` versions of PHPMatcher.
 
-### Creating Matcher
-
+**Creating Matcher:** 
 ```diff
 -$factory = new MatcherFactory();
--$this->matcher = $factory->createMatcher();
+-$matcher = $factory->createMatcher();
++$matcher = new PHPMatcher();
 ```
 
-```diff
-+$this->matcher = new PHPMatcher();
-```
-
-### Simple Matching
-
+**Using Matcher**
 ```diff
 -PHPMatcher::match($value, $pattern, $error)
++$matcher = (new PHPMatcher())->match($value, $pattern);;
 ```
 
+**Accessing last error/backtrace**
 ```diff
 +$matcher = new PHPMatcher();
 +$matcher->match($value, $pattern);
 +echo $matcher->error();
++echo $matcher->backtrace();
 ```

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "openlss/lib-array2xml": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0|^8.0",
+        "phpunit/phpunit": "^8.4",
         "friendsofphp/php-cs-fixer": "^2.4"
     },
     "autoload": {

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -104,6 +104,11 @@ final class Backtrace
         );
     }
 
+    public function isEmpty() : bool
+    {
+        return \count($this->trace) === 0;
+    }
+
     public function __toString() : string
     {
         return \implode("\n", $this->trace);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,5 +6,5 @@ namespace Coduo\PHPMatcher;
 
 interface Factory
 {
-    public function createMatcher(Backtrace $backtrace = null) : Matcher;
+    public function createMatcher() : Matcher;
 }

--- a/src/Factory/MatcherFactory.php
+++ b/src/Factory/MatcherFactory.php
@@ -12,9 +12,9 @@ use Coduo\PHPMatcher\Parser;
 
 final class MatcherFactory implements Factory
 {
-    public function createMatcher(Backtrace $backtrace = null) : Matcher
+    public function createMatcher() : Matcher
     {
-        $matcherBacktrace = $backtrace ? $backtrace : new Backtrace();
+        $matcherBacktrace = new Backtrace();
 
         return new Matcher($this->buildMatchers($this->buildParser($matcherBacktrace), $matcherBacktrace), $matcherBacktrace);
     }

--- a/src/Factory/SimpleFactory.php
+++ b/src/Factory/SimpleFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Factory;
 
-use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\Factory;
 use Coduo\PHPMatcher\Matcher;
 
@@ -13,7 +12,7 @@ use Coduo\PHPMatcher\Matcher;
  */
 class SimpleFactory implements Factory
 {
-    public function createMatcher(Backtrace $backtrace = null) : Matcher
+    public function createMatcher() : Matcher
     {
         return (new MatcherFactory())->createMatcher();
     }

--- a/src/PHPMatcher.php
+++ b/src/PHPMatcher.php
@@ -8,27 +8,43 @@ use Coduo\PHPMatcher\Factory\MatcherFactory;
 
 final class PHPMatcher
 {
-    public static function match($value, $pattern, string &$error = null) : bool
+    private $matcher;
+
+    public function match($value, $pattern) : bool
     {
-        $matcher = (new MatcherFactory())->createMatcher();
+        $this->matcher = null;
 
-        if (!$matcher->match($value, $pattern)) {
-            $error = $matcher->getError();
-            return false;
-        }
-
-        return true;
+        return $this->getMatcher()->match($value, $pattern);
     }
 
-    public static function matchBacktrace($value, $pattern, Backtrace $backtrace, string &$error = null) : bool
+    /**
+     * Returns backtrace from last matching.
+     * When called before PHPMatcher::match() function it will return instance where Backtrace::isEmpty() will return true
+     *
+     * @return Backtrace
+     */
+    public function backtrace() : Backtrace
     {
-        $matcher = (new MatcherFactory())->createMatcher($backtrace);
+        return $this->getMatcher()->backtrace();
+    }
 
-        if (!$matcher->match($value, $pattern)) {
-            $error = $matcher->getError();
-            return false;
+    /**
+     * Returns error from last matching.
+     * If last matching was successful this function will return null.
+     *
+     * @return string|null
+     */
+    public function error() : ?string
+    {
+        return $this->getMatcher()->getError();
+    }
+
+    private function getMatcher() : Matcher
+    {
+        if (null === $this->matcher) {
+            $this->matcher = (new MatcherFactory())->createMatcher();
         }
 
-        return true;
+        return $this->matcher;
     }
 }

--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\PHPUnit;
 
-use Coduo\PHPMatcher\Backtrace;
-use Coduo\PHPMatcher\Factory\MatcherFactory;
-use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Util\Json;
 use SebastianBergmann\Comparator\ComparisonFailure;
@@ -15,7 +13,6 @@ final class PHPMatcherConstraint extends Constraint
 {
     private $pattern;
     private $matcher;
-    private $backtrace;
     private $lastValue;
 
     public function __construct($pattern)
@@ -33,8 +30,7 @@ final class PHPMatcherConstraint extends Constraint
         }
 
         $this->pattern = $pattern;
-        $this->backtrace = new Backtrace();
-        $this->matcher = $this->createMatcher();
+        $this->matcher = new PHPMatcher();
     }
 
     /**
@@ -42,22 +38,20 @@ final class PHPMatcherConstraint extends Constraint
      */
     public function toString() : string
     {
-        return 'matches the pattern';
+        return 'matches given pattern.';
     }
 
     protected function failureDescription($other): string
     {
-        return parent::failureDescription($other) . ".\nError: " . $this->matcher->getError();
+        return parent::failureDescription($other)
+            . "\nPattern: " . $this->exporter()->export($this->pattern)
+            . "\nError: " . $this->matcher->error()
+            . "\nBacktrace: \n" . $this->matcher->backtrace();
     }
 
     protected function matches($value) : bool
     {
         return $this->matcher->match($this->lastValue = $value, $this->pattern);
-    }
-
-    private function createMatcher() : Matcher
-    {
-        return (new MatcherFactory())->createMatcher($this->backtrace);
     }
 
     /**

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -4,21 +4,19 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests;
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
-use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\TestCase;
 
 final class BacktraceTest extends TestCase
 {
     /**
-     * @var Matcher
+     * @var PHPMatcher
      */
     protected $matcher;
 
     public function setUp() : void
     {
-        $factory = new MatcherFactory();
-        $this->matcher = $factory->createMatcher();
+        $this->matcher = new PHPMatcher();
     }
 
     public function test_backtrace_in_failed_simple_matching()

--- a/tests/EmptyPatternsTest.php
+++ b/tests/EmptyPatternsTest.php
@@ -4,22 +4,19 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests;
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
-use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\TestCase;
 
 final class EmptyPatternsTest extends TestCase
 {
     /**
-     * @var Matcher
+     * @var PHPMatcher
      */
     protected $matcher;
 
     public function setUp() : void
     {
-        $factory = new MatcherFactory();
-        $this->matcher = $factory->createMatcher();
+        $this->matcher = new PHPMatcher();
     }
 
     /**
@@ -29,7 +26,6 @@ final class EmptyPatternsTest extends TestCase
     {
         $match = $this->matcher->match($value, $pattern);
         $this->assertSame($expectedResult, $match);
-        $this->assertSame($expectedResult, PHPMatcher::match($value, $pattern));
     }
 
     public static function emptyPatternString()

--- a/tests/ExpandersTest.php
+++ b/tests/ExpandersTest.php
@@ -4,22 +4,19 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests;
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
-use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\TestCase;
 
 final class ExpandersTest extends TestCase
 {
     /**
-     * @var Matcher
+     * @var PHPMatcher
      */
     protected $matcher;
 
     public function setUp() : void
     {
-        $factory = new MatcherFactory();
-        $this->matcher = $factory->createMatcher();
+        $this->matcher = new PHPMatcher();
     }
 
     /**
@@ -27,8 +24,7 @@ final class ExpandersTest extends TestCase
      */
     public function test_expanders($value, $pattern, $expectedResult)
     {
-        $this->assertSame($expectedResult, $this->matcher->match($value, $pattern), (string) $this->matcher->getError());
-        $this->assertSame($expectedResult, PHPMatcher::match($value, $pattern));
+        $this->assertSame($expectedResult, $this->matcher->match($value, $pattern), (string) $this->matcher->error());
     }
 
     public static function expanderExamples()

--- a/tests/Factory/SimpleFactoryTest.php
+++ b/tests/Factory/SimpleFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Tests;
 
 use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Matcher;
 use PHPUnit\Framework\TestCase;
 
 class SimpleFactoryTest extends TestCase
@@ -12,6 +13,6 @@ class SimpleFactoryTest extends TestCase
     public function test_creating_matcher()
     {
         $factory = new SimpleFactory();
-        $this->assertInstanceOf('Coduo\PHPMatcher\Matcher', $factory->createMatcher());
+        $this->assertInstanceOf(Matcher::class, $factory->createMatcher());
     }
 }

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests;
 
-use Coduo\PHPMatcher\PHPMatcher;
 use Coduo\PHPMatcher\PHPUnit\PHPMatcherTestCase;
 
 class MatcherTest extends PHPMatcherTestCase
@@ -15,7 +14,6 @@ class MatcherTest extends PHPMatcherTestCase
     public function test_matcher_with_scalar_values($value, $pattern)
     {
         $this->assertMatchesPattern($pattern, $value);
-        $this->assertTrue(PHPMatcher::match($value, $pattern));
     }
 
     public function test_matcher_with_array_value()
@@ -59,7 +57,6 @@ class MatcherTest extends PHPMatcherTestCase
         ];
 
         $this->assertMatchesPattern($pattern, $value);
-        $this->assertTrue(PHPMatcher::match($value, $pattern, $error), (string) $error);
     }
 
     /**
@@ -68,7 +65,6 @@ class MatcherTest extends PHPMatcherTestCase
     public function test_matcher_with_json($value, $pattern)
     {
         $this->assertMatchesPattern($pattern, $value);
-        $this->assertTrue(PHPMatcher::match($value, $pattern));
     }
 
     public function test_matcher_with_xml()
@@ -105,7 +101,6 @@ XML;
 XML;
 
         $this->assertMatchesPattern($pattern, $value);
-        $this->assertTrue(PHPMatcher::match($value, $pattern));
     }
 
     public function test_matcher_with_xml_including_optional_node()
@@ -143,7 +138,6 @@ XML;
 XML;
 
         $this->assertMatchesPattern($pattern, $value);
-        $this->assertTrue(PHPMatcher::match($value, $pattern));
     }
 
     public function test_full_text_matcher()
@@ -151,7 +145,6 @@ XML;
         $value = 'lorem ipsum 1234 random text';
         $pattern = "@string@.startsWith('lo') ipsum @number@.greaterThan(10) random text";
         $this->assertMatchesPattern($pattern, $value);
-        $this->assertTrue(PHPMatcher::match($value, $pattern));
     }
 
     public function test_matcher_with_callback()
@@ -162,20 +155,12 @@ XML;
             },
             'test'
         );
-        $this->assertTrue(PHPMatcher::match('test', function ($value) {
-            return $value === 'test';
-        }));
-        $this->assertFalse(PHPMatcher::match('test', function ($value) {
-            return $value !== 'test';
-        }));
     }
 
     public function test_matcher_with_wildcard()
     {
         $this->assertMatchesPattern('@*@', 'test');
-        $this->assertTrue(PHPMatcher::match('test', '@*@'));
         $this->assertMatchesPattern('@wildcard@', 'test');
-        $this->assertTrue(PHPMatcher::match('test', '@wildcard@'));
     }
 
     /**

--- a/tests/OrMatcherTest.php
+++ b/tests/OrMatcherTest.php
@@ -4,22 +4,19 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests;
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
-use Coduo\PHPMatcher\Matcher;
 use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\TestCase;
 
 final class OrMatcherTest extends TestCase
 {
     /**
-     * @var Matcher
+     * @var PHPMatcher
      */
     protected $matcher;
 
     public function setUp() : void
     {
-        $factory = new MatcherFactory();
-        $this->matcher = $factory->createMatcher();
+        $this->matcher = new PHPMatcher();
     }
 
     /**
@@ -28,7 +25,6 @@ final class OrMatcherTest extends TestCase
     public function test_matcher_with_or($value, $pattern, $expectedResult)
     {
         $this->assertSame($expectedResult, $this->matcher->match($value, $pattern));
-        $this->assertSame($expectedResult, PHPMatcher::match($value, $pattern));
     }
 
     public static function orExamples()

--- a/tests/PHPUnit/PHPMatcherAssertionsTest.php
+++ b/tests/PHPUnit/PHPMatcherAssertionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Tests\PHPUnit;
 
 use Coduo\PHPMatcher\PHPUnit\PHPMatcherAssertions;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 
 class PHPMatcherAssertionsTest extends TestCase
@@ -18,16 +19,46 @@ class PHPMatcherAssertionsTest extends TestCase
 
     public function test_it_throws_an_expectation_failed_exception_if_a_value_does_not_match_the_pattern()
     {
-        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
-        $this->expectExceptionMessage("Failed asserting that '{\"foo\":\"bar\"}' matches the pattern");
+        $this->expectException(AssertionFailedError::class);
+
+        /**
+         * Expected console output:
+         *
+         * Failed asserting that '{"foo":"bar"}' matches given pattern.
+         * Pattern: '{"foo": "@integer@"}'
+         * Error: Value {"foo":"bar"} does not match pattern {"foo":"@integer@"}
+         * Backtrace:
+         * #1 Matcher Coduo\PHPMatcher\Matcher matching value "{"foo":"bar"}" with "{"foo":"@integer@"}" pattern
+         * #2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) matching value "{"foo":"bar"}" with "{"foo":"@integer@"}" pattern
+         * #3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "{"foo":"@integer@"}"
+         * #...
+         * #66 Matcher Coduo\PHPMatcher\Matcher error: Value {"foo":"bar"} does not match pattern {"foo":"@integer@"}.
+         */
+        $this->expectExceptionMessageMatches("/Failed asserting that '{\"foo\":\"bar\"}' matches given pattern.\nPattern: '{\"foo\": \"@integer@\"}'\nError: Value {\"foo\":\"bar\"} does not match pattern {\"foo\":\"@integer@\"}\nBacktrace: \n(.*)/");
 
         $this->assertMatchesPattern('{"foo": "@integer@"}', \json_encode(['foo' => 'bar']));
     }
 
     public function test_it_creates_a_constraint_for_stubs()
     {
-        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that 42 matches the pattern.');
+        $this->expectException(AssertionFailedError::class);
+
+        /**
+         *  Expected console output:
+         *
+         *  Expectation failed for method name is "getTitle" when invoked zero or more time s
+         *  Parameter 0 for invocation stdClass::getTitle(42) does not match expected value.
+         *  Failed asserting that 42 matches given pattern.
+         *  Pattern: '@string@'
+         *  Error: integer "42" is not a valid string.
+         *  Backtrace:
+         *  #1 Matcher Coduo\PHPMatcher\Matcher matching value "42" with "@string@" pattern
+         *  #2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) matching value "42" with "@string@" pattern
+         *  #3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@string@"
+         *  #...
+         *  #35 Matcher Coduo\PHPMatcher\Matcher error: integer "42" is not a valid string.
+         */
+        $this->expectExceptionMessageMatches("/Expectation failed for method name is \"getTitle\" when invoked zero or more times\nParameter 0 for invocation stdClass::getTitle\(42\) does not match expected value.\nFailed asserting that 42 matches given pattern.\nPattern: '@string@'\nError: integer \"42\" is not a valid string.\nBacktrace: \n(.*)/");
 
         $mock = $this->getMockBuilder('stdClass')
             ->setMethods(['getTitle'])
@@ -38,10 +69,5 @@ class PHPMatcherAssertionsTest extends TestCase
             ->willReturn('foo');
 
         $mock->getTitle(42);
-    }
-
-    public function test_it_asserts_if_a_value_matches_the_array_pattern()
-    {
-        $this->assertMatchesPattern(['foo' => '@string@'], ['foo' => 'bar']);
     }
 }

--- a/tests/PHPUnit/PHPMatcherConstraintTest.php
+++ b/tests/PHPUnit/PHPMatcherConstraintTest.php
@@ -33,7 +33,7 @@ class PHPMatcherConstraintTest extends TestCase
     public function test_it_sets_a_failure_description_if_not_given()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that 42 matches the pattern');
+        $this->expectExceptionMessageMatches('/Failed asserting that 42 matches given pattern(.*)/');
 
         $constraint = new PHPMatcherConstraint('@string@');
 

--- a/tests/PHPUnit/PHPMatcherTestCaseTest.php
+++ b/tests/PHPUnit/PHPMatcherTestCaseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Tests\PHPUnit;
 
 use Coduo\PHPMatcher\PHPUnit\PHPMatcherTestCase;
+use PHPUnit\Framework\AssertionFailedError;
 
 class PHPMatcherTestCaseTest extends PHPMatcherTestCase
 {
@@ -15,16 +16,16 @@ class PHPMatcherTestCaseTest extends PHPMatcherTestCase
 
     public function test_it_throws_an_expectation_failed_exception_if_a_value_does_not_match_the_pattern()
     {
-        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
-        $this->expectExceptionMessage("Failed asserting that '{\"foo\":\"bar\"}' matches the pattern");
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessageMatches("/Failed asserting that '{\"foo\":\"bar\"}' matches given pattern(.*)/");
 
         $this->assertMatchesPattern('{"foo": "@integer@"}', \json_encode(['foo' => 'bar']));
     }
 
     public function test_it_creates_a_constraint_for_stubs()
     {
-        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that 42 matches the pattern.');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessageMatches('/Failed asserting that 42 matches given pattern(.*)/');
 
         $mock = $this->getMockBuilder('stdClass')
             ->setMethods(['getTitle'])

--- a/tests/ParserSyntaxErrorTest.php
+++ b/tests/ParserSyntaxErrorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Tests;
 
 use Coduo\PHPMatcher\Backtrace;
+use Coduo\PHPMatcher\Exception\PatternException;
 use Coduo\PHPMatcher\Lexer;
 use Coduo\PHPMatcher\Parser;
 use PHPUnit\Framework\TestCase;
@@ -23,7 +24,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function test_unexpected_statement_at_type_position()
     {
-        $this->expectException(\Coduo\PHPMatcher\Exception\PatternException::class);
+        $this->expectException(PatternException::class);
         $this->expectExceptionMessage('[Syntax Error] line 0, col 0: Error: Expected "@type@ pattern", got "not"');
 
         $this->parser->getAST('not_valid_type');
@@ -31,7 +32,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function test_unexpected_statement_instead_of_expander()
     {
-        $this->expectException(\Coduo\PHPMatcher\Exception\PatternException::class);
+        $this->expectException(PatternException::class);
         $this->expectExceptionMessage('[Syntax Error] line 0, col 6: Error: Expected ".expanderName(args) definition", got "anything"');
 
         $this->parser->getAST('@type@anything');
@@ -39,7 +40,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function test_end_of_string_after_opening_parenthesis()
     {
-        $this->expectException(\Coduo\PHPMatcher\Exception\PatternException::class);
+        $this->expectException(PatternException::class);
         $this->expectExceptionMessage('[Syntax Error] line 0, col 14: Error: Expected ")", got end of string.end of string');
 
         $this->parser->getAST('@type@.expander(');
@@ -47,7 +48,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function test_not_argument_after_opening_parenthesis()
     {
-        $this->expectException(\Coduo\PHPMatcher\Exception\PatternException::class);
+        $this->expectException(PatternException::class);
         $this->expectExceptionMessage('[Syntax Error] line 0, col 16: Error: Expected "string, number, boolean or null argument", got "not"');
 
         $this->parser->getAST('@type@.expander(not_argument');
@@ -55,7 +56,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function test_missing_close_parenthesis_after_single_argument()
     {
-        $this->expectException(\Coduo\PHPMatcher\Exception\PatternException::class);
+        $this->expectException(PatternException::class);
         $this->expectExceptionMessage('[Syntax Error] line 0, col 22: Error: Expected ")", got end of string.end of string');
 
         $this->parser->getAST("@type@.expander('string'");
@@ -63,7 +64,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function test_missing_close_parenthesis_after_multiple_arguments()
     {
-        $this->expectException(\Coduo\PHPMatcher\Exception\PatternException::class);
+        $this->expectException(PatternException::class);
         $this->expectExceptionMessage('[Syntax Error] line 0, col 26: Error: Expected ")", got end of string.end of string');
 
         $this->parser->getAST("@type@.expander('string',1");
@@ -71,7 +72,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function test_missing_argument_after_comma()
     {
-        $this->expectException(\Coduo\PHPMatcher\Exception\PatternException::class);
+        $this->expectException(PatternException::class);
         $this->expectExceptionMessage('[Syntax Error] line 0, col 25: Error: Expected "string, number, boolean or null argument", got ")"');
 
         $this->parser->getAST("@type@.expander('string',)");
@@ -79,7 +80,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function test_not_argument_after_comma()
     {
-        $this->expectException(\Coduo\PHPMatcher\Exception\PatternException::class);
+        $this->expectException(PatternException::class);
         $this->expectExceptionMessage('[Syntax Error] line 0, col 25: Error: Expected "string, number, boolean or null argument", got "not"');
 
         $this->parser->getAST("@type@.expander('string',not_argument");


### PR DESCRIPTION
PHPMatcher API cleanup that replaces facade with regular class allowing to access last message/backtrace. 

### Changes

**Creating Matcher:** 
```diff
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
```

**Using Matcher**
```diff
-PHPMatcher::match($value, $pattern, $error)
+$matcher = (new PHPMatcher())->match($value, $pattern);;
```

**Accessing last error/backtrace**
```diff
+$matcher = new PHPMatcher();
+$matcher->match($value, $pattern);
+echo $matcher->error();
+echo $matcher->backtrace();
```
