### PR TITLE
Fix JsonMatcher support for JSON pattern including another pattern in the middle of a string value

### DIFF
--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -151,6 +151,7 @@ class JsonMatcherTest extends TestCase
             [\json_encode(['Norbert', 'Michał'])],
             [\json_encode(['Norbert', '@string@'])],
             [\json_encode('test')],
+            [\json_encode(['foo' => '/foo/@uuid@/bar'])],
         ];
     }
 


### PR DESCRIPTION
Fixes #183.

Note that [tests pass on master](https://travis-ci.org/coduo/php-matcher/builds/616234884) but I think it's a side effect on an unrelated change because I didn't find any test case that covers this specific issue.