### PR TITLE
Fixed json matcher when matching strings including other patterns

### DIFF
--- a/src/Matcher/JsonMatcher.php
+++ b/src/Matcher/JsonMatcher.php
@@ -31,8 +31,9 @@ final class JsonMatcher extends Matcher
             return false;
         }
 
-        $transformedPattern = Json::transformPattern($pattern);
+        $transformedPattern = Json::isValid($pattern) ? $pattern : Json::transformPattern($pattern);
         $match = $this->matcher->match(\json_decode($value, true), \json_decode($transformedPattern, true));
+
         if (!$match) {
             $this->error = $this->matcher->getError();
             return false;

--- a/src/Matcher/Pattern/Assert/Json.php
+++ b/src/Matcher/Pattern/Assert/Json.php
@@ -28,7 +28,7 @@ final class Json
             return false;
         }
 
-        return self::isValid(self::transformPattern($value));
+        return self::isValid($value) || self::isValid(self::transformPattern($value));
     }
 
     public static function transformPattern(string $pattern) : string

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -151,6 +151,7 @@ class JsonMatcherTest extends TestCase
             [\json_encode(['Norbert', 'Michał'])],
             [\json_encode(['Norbert', '@string@'])],
             [\json_encode('test')],
+            [\json_encode(['foo' => '/foo/@uuid@/bar'])],
         ];
     }
 

--- a/tests/MatcherTest.php
+++ b/tests/MatcherTest.php
@@ -131,6 +131,12 @@ class MatcherTest extends TestCase
                     "nextPage": "@string@"
                 }',
             ],
+            'matches with txt matcher ' => [
+                /** @lang JSON */
+                '{"foo": "/foo/92ff9a6c-7fbd-47e5-b550-90b77e3284c7/bar"}',
+                /** @lang JSON */
+                '{"foo": "/foo/@uuid@/bar"}'
+            ],
             'matches json values with full text matcher' => [
                 /** @lang JSON */
                 '{


### PR DESCRIPTION
Fixes #187, Json class was indeed broken but it wasn't affecting whole Matcher since it's not JsonMatcher that should be used to match `/foo/@uuid@/bar` but TextMatcher