### PR TITLE
 README.md - fix example in "Json matching with unbounded arrays and objects" (3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,8 +317,9 @@ $matcher->match(
         "firstName": "Norbert",
         "lastName": "Orzechowicz",
         "created": "2014-01-01",
-        "roles":["ROLE_USER", "ROLE_DEVELOPER"]}
-      ]
+        "roles":["ROLE_USER", "ROLE_DEVELOPER"]
+      }
+    ]
   }',
   '{
     "users":[
@@ -351,10 +352,10 @@ $matcher->match(
         "firstName": "Norbert",
         "lastName": "Orzechowicz",
         "created": "2014-01-01",
-        "roles":["ROLE_USER", "ROLE_DEVELOPER"]},
+        "roles":["ROLE_USER", "ROLE_DEVELOPER"],
         "attributes": {
           "isAdmin": false,
-          "dateOfBirth" null,
+          "dateOfBirth": null,
           "hasEmailVerified": true
         }
       },
@@ -362,10 +363,10 @@ $matcher->match(
         "firstName": "Michał",
         "lastName": "Dąbrowski",
         "created": "2014-01-01",
-        "roles":["ROLE_USER", "ROLE_DEVELOPER", "ROLE_ADMIN"]},
+        "roles":["ROLE_USER", "ROLE_DEVELOPER", "ROLE_ADMIN"],
         "attributes": {
           "isAdmin": true,
-          "dateOfBirth" null,
+          "dateOfBirth": null,
           "hasEmailVerified": true
         }
       }
@@ -386,8 +387,9 @@ $matcher->match(
           "@*@": "@*@"
         }
       }
-    ],
-    @...@
+      ,
+      @...@
+    ]
   }'
 );
 ```


### PR DESCRIPTION
Fixed invalid json in part "Json matching with unbounded arrays and objects"

PR is against branch "3.1" because example  "Json matching with unbounded arrays and objects" was introduced there.