### PR TITLE
Fixed handling arrays with keys having brackets in array matcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
       env: DEPENDENCIES='low'
     - php: 7.2
     - php: 7.3
+    - php: 7.4
 
 before_install:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PHPMatcher::error() : ?string;
 It was built to simplify API's functional testing.
 
 * [![Build Status](https://travis-ci.org/coduo/php-matcher.svg)](https://travis-ci.org/coduo/php-matcher) - [5.0 (master) README](https://github.com/coduo/php-matcher/tree/master/README.md)  PHP >= 7.2
-* [![Build Status](https://travis-ci.org/coduo/php-matcher.svg?branch=4.0)](https://travis-ci.org/coduo/php-matcher) - [4.0 (master) README](https://github.com/coduo/php-matcher/tree/4.0/README.md)  PHP >= 7.2
+* [![Build Status](https://travis-ci.org/coduo/php-matcher.svg?branch=4.0)](https://travis-ci.org/coduo/php-matcher) - [4.0.* README](https://github.com/coduo/php-matcher/tree/4.0/README.md)  PHP >= 7.2
 * [![Build Status](https://travis-ci.org/coduo/php-matcher.svg?branch=3.2)](https://travis-ci.org/coduo/php-matcher) - [3.2.* README](https://github.com/coduo/php-matcher/tree/3.2/README.md) PHP >= 7.0 
 * [![Build Status](https://travis-ci.org/coduo/php-matcher.svg?branch=3.1)](https://travis-ci.org/coduo/php-matcher) - [3.1.* README](https://github.com/coduo/php-matcher/tree/3.1/README.md) PHP >= 7.0  
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "ext-filter": "*",
         "ext-json": "*",
         "coduo/php-to-string": "^3",
-        "symfony/property-access": "^2.3|^3.0|^4.0|^5.0",
         "symfony/expression-language": "^2.3|^3.0|^4.0|^5.0",
         "doctrine/lexer": "^1.0",
         "openlss/lib-array2xml": "^1.0"

--- a/tests/Matcher/ArrayMatcherTest.php
+++ b/tests/Matcher/ArrayMatcherTest.php
@@ -229,6 +229,7 @@ class ArrayMatcherTest extends TestCase
                 ],
                 $simpleArrPattern,
             ],
+            [['foo[key]' => 'value'], ['foo[key]' => '@string@']]
         ];
     }
 


### PR DESCRIPTION
Array matcher is throwing an exception when array has a key with brackets. 

See example below:

Value:
```
{
  "foo[key]": "value"
}
```

Pattern:
```
{
  "foo[key]": "@string@"
}
```

The reason for that is because `Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException` is thrown in `Symfony\Component\PropertyAccess\PropertyPath` constructor because such key does not match regex for valid property.

This PR attempts to fix it.

I looked into the usage of `PropertyPath` and `PropertyAccessor` in `ArrayMatcher` and it seems that it was needed only to perform simple operation (basically stripping `[` and `]` from beginning and end of a path string). I simplified the operation by adding a method `getKeyFromAccessPath` instead of relying on `PropertyAccessor`.

All tests passed so I assume that it will not break anything else :)

Additionally, it turned out that `symfony/property-access` is not used anywhere else in the project so I removed it from Composer dependencies.
