### PR TITLE
Make Backtrace optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,9 @@ class MatcherTest extends TestCase
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(1, 1);
 $matcher->match('string', 'string');
@@ -148,10 +147,9 @@ $matcher->match('string', 'string');
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match('Norbert', '@string@');
 $matcher->match("lorem ipsum dolor", "@string@.startsWith('lorem').contains('ipsum').endsWith('dolor')");
@@ -163,10 +161,9 @@ $matcher->match("lorem ipsum dolor", "@string@.startsWith('lorem').contains('ips
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match('2014-08-19', '@string@.isDateTime()');
 $matcher->match('2014-08-19', '@string@.isDateTime().before("2016-08-19")');
@@ -179,10 +176,9 @@ $matcher->match('2014-08-19', '@string@.isDateTime().before("today").after("+ 10
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(100, '@integer@');
 $matcher->match(100, '@integer@.lowerThan(200).greaterThan(10)');
@@ -194,10 +190,9 @@ $matcher->match(100, '@integer@.lowerThan(200).greaterThan(10)');
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(100, '@number@');
 $matcher->match('200', '@number@');
@@ -211,10 +206,9 @@ $matcher->match(0b10100111001, '@number@');
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(10.1, "@double@");
 $matcher->match(10.1, "@double@.lowerThan(50.12).greaterThan(10)");
@@ -225,10 +219,9 @@ $matcher->match(10.1, "@double@.lowerThan(50.12).greaterThan(10)");
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(true, "@boolean@");
 $matcher->match(false, "@boolean@");
@@ -239,10 +232,9 @@ $matcher->match(false, "@boolean@");
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match("@integer@", "@*@");
 $matcher->match("foobar", "@*@");
@@ -257,10 +249,9 @@ $matcher->match(new \stdClass, "@wildcard@");
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(new \DateTime('2014-04-01'), "expr(value.format('Y-m-d') == '2014-04-01'");
 $matcher->match("Norbert", "expr(value === 'Norbert')");
@@ -271,10 +262,9 @@ $matcher->match("Norbert", "expr(value === 'Norbert')");
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match('9f4db639-0e87-4367-9beb-d64e3f42ae18', '@uuid@');
 ```
@@ -284,10 +274,9 @@ $matcher->match('9f4db639-0e87-4367-9beb-d64e3f42ae18', '@uuid@');
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(
    array(
@@ -343,10 +332,9 @@ $matcher->match(
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(
   '{
@@ -378,10 +366,9 @@ $matcher->match(
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(
   '{
@@ -442,10 +429,9 @@ $matcher->match(
 ```php
 <?php
 
-use Coduo\PHPMatcher\Factory\MatcherFactory;
+use Coduo\PHPMatcher\PHPMatcher;
 
-$factory = new MatcherFactory();
-$matcher = $factory->createMatcher();
+$matcher = new PHPMatcher();
 
 $matcher->match(<<<XML
 <?xml version="1.0"?>

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,36 @@
+# 4.0 -> 5.0
+
+**Backtrace** 
+
+In order to improve performance of matcher `Backtrace` class was replaced `InMemoryBacktrace`
+that implements `Backtrace` interface. 
+
+In order to use backtrace provide it directly to `MatcherFactory` or `PHPMatcher` class.
+
+PHPUnit tests require `setBacktrace` method to be used before test:
+
+```php
+$this->setBacktrace($backtrace = new InMemoryBacktrace());
+$this->assertMatchesPattern('{"foo": "@integer@"}', json_encode(['foo' => 'bar']));
+```
+
+**Optional Matchers**
+
+XML and Expression matchers are now optional, in order to use them add following 
+dependencies to your composer.json file:
+
+XMLMatcher
+
+```
+"openlss/lib-array2xml": "^1.0"
+```
+
+ExpressionMatcher
+
+```
+symfony/expression-language
+```
+
 # 3.x -> 4.0 
 
 Below you can find list of changes between `3.x` and `4.0` versions of PHPMatcher.

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -4,129 +4,25 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher;
 
-use Coduo\PHPMatcher\Value\SingleLineString;
-use Coduo\ToString\StringConverter;
-use function sprintf;
-use function implode;
-use function count;
-
-final class Backtrace
+interface Backtrace
 {
-    /**
-     * @var mixed[]
-     */
-    private $trace;
+    public function matcherCanMatch(string $name, $value, bool $result) : void;
 
-    public function __construct()
-    {
-        $this->trace = [];
-    }
+    public function matcherEntrance(string $name, $value, $pattern) : void;
 
-    public function matcherCanMatch(string $name, $value, bool $result) : void
-    {
-        $this->trace[] = sprintf(
-            '#%d Matcher %s %s match pattern "%s"',
-            $this->entriesCount(),
-            $name,
-            $result ? 'can' : 'can\'t',
-            new SingleLineString((string) new StringConverter($value))
-        );
-    }
+    public function matcherSucceed(string $name, $value, $pattern) : void;
 
-    public function matcherEntrance(string $name, $value, $pattern) : void
-    {
-        $this->trace[] = sprintf(
-            '#%d Matcher %s matching value "%s" with "%s" pattern',
-            $this->entriesCount(),
-            $name,
-            new SingleLineString((string) new StringConverter($value)),
-            new SingleLineString((string) new StringConverter($pattern))
-        );
-    }
+    public function matcherFailed(string $name, $value, $pattern, string $error) : void;
 
-    public function matcherSucceed(string $name, $value, $pattern) : void
-    {
-        $this->trace[] = sprintf(
-            '#%d Matcher %s successfully matched value "%s" with "%s" pattern',
-            $this->entriesCount(),
-            $name,
-            new SingleLineString((string) new StringConverter($value)),
-            new SingleLineString((string) new StringConverter($pattern))
-        );
-    }
+    public function expanderEntrance(string $name, $value) : void;
 
-    public function matcherFailed(string $name, $value, $pattern, string $error) : void
-    {
-        $this->trace[] = sprintf(
-            '#%d Matcher %s failed to match value "%s" with "%s" pattern',
-            $this->entriesCount(),
-            $name,
-            new SingleLineString((string) new StringConverter($value)),
-            new SingleLineString((string) new StringConverter($pattern))
-        );
+    public function expanderSucceed(string $name, $value) : void;
 
-        $this->trace[] = sprintf(
-            '#%d Matcher %s error: %s',
-            $this->entriesCount(),
-            $name,
-            new SingleLineString($error)
-        );
-    }
+    public function expanderFailed(string $name, $value, string $error) : void;
 
-    public function expanderEntrance(string $name, $value) : void
-    {
-        $this->trace[] = sprintf(
-            '#%d Expander %s matching value "%s"',
-            $this->entriesCount(),
-            $name,
-            new SingleLineString((string) new StringConverter($value))
-        );
-    }
+    public function isEmpty() : bool;
 
-    public function expanderSucceed(string $name, $value) : void
-    {
-        $this->trace[] = sprintf(
-            '#%d Expander %s successfully matched value "%s"',
-            $this->entriesCount(),
-            $name,
-            new SingleLineString((string) new StringConverter($value))
-        );
-    }
+    public function __toString() : string;
 
-    public function expanderFailed(string $name, $value, string $error) : void
-    {
-        $this->trace[] = sprintf(
-            '#%d Expander %s failed to match value "%s"',
-            $this->entriesCount(),
-            $name,
-            new SingleLineString((string) new StringConverter($value))
-        );
-
-        $this->trace[] = sprintf(
-            '#%d Expander %s error: %s',
-            $this->entriesCount(),
-            $name,
-            new SingleLineString($error)
-        );
-    }
-
-    public function isEmpty() : bool
-    {
-        return count($this->trace) === 0;
-    }
-
-    public function __toString() : string
-    {
-        return implode("\n", $this->trace);
-    }
-
-    public function raw() : array
-    {
-        return $this->trace;
-    }
-
-    private function entriesCount(): int
-    {
-        return count($this->trace) + 1;
-    }
+    public function raw() : array;
 }

--- a/src/Backtrace/InMemoryBacktrace.php
+++ b/src/Backtrace/InMemoryBacktrace.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Backtrace;
+
+use Coduo\PHPMatcher\Backtrace;
+use Coduo\PHPMatcher\Value\SingleLineString;
+use Coduo\ToString\StringConverter;
+
+final class InMemoryBacktrace implements Backtrace
+{
+    /**
+     * @var mixed[]
+     */
+    private $trace;
+
+    public function __construct()
+    {
+        $this->trace = [];
+    }
+
+    public function matcherCanMatch(string $name, $value, bool $result) : void
+    {
+        $this->trace[] = sprintf(
+            '#%d Matcher %s %s match pattern "%s"',
+            $this->entriesCount(),
+            $name,
+            $result ? 'can' : 'can\'t',
+            new SingleLineString((string) new StringConverter($value))
+        );
+    }
+
+    public function matcherEntrance(string $name, $value, $pattern) : void
+    {
+        $this->trace[] = sprintf(
+            '#%d Matcher %s matching value "%s" with "%s" pattern',
+            $this->entriesCount(),
+            $name,
+            new SingleLineString((string) new StringConverter($value)),
+            new SingleLineString((string) new StringConverter($pattern))
+        );
+    }
+
+    public function matcherSucceed(string $name, $value, $pattern) : void
+    {
+        $this->trace[] = sprintf(
+            '#%d Matcher %s successfully matched value "%s" with "%s" pattern',
+            $this->entriesCount(),
+            $name,
+            new SingleLineString((string) new StringConverter($value)),
+            new SingleLineString((string) new StringConverter($pattern))
+        );
+    }
+
+    public function matcherFailed(string $name, $value, $pattern, string $error) : void
+    {
+        $this->trace[] = sprintf(
+            '#%d Matcher %s failed to match value "%s" with "%s" pattern',
+            $this->entriesCount(),
+            $name,
+            new SingleLineString((string) new StringConverter($value)),
+            new SingleLineString((string) new StringConverter($pattern))
+        );
+
+        $this->trace[] = sprintf(
+            '#%d Matcher %s error: %s',
+            $this->entriesCount(),
+            $name,
+            new SingleLineString($error)
+        );
+    }
+
+    public function expanderEntrance(string $name, $value) : void
+    {
+        $this->trace[] = sprintf(
+            '#%d Expander %s matching value "%s"',
+            $this->entriesCount(),
+            $name,
+            new SingleLineString((string) new StringConverter($value))
+        );
+    }
+
+    public function expanderSucceed(string $name, $value) : void
+    {
+        $this->trace[] = sprintf(
+            '#%d Expander %s successfully matched value "%s"',
+            $this->entriesCount(),
+            $name,
+            new SingleLineString((string) new StringConverter($value))
+        );
+    }
+
+    public function expanderFailed(string $name, $value, string $error) : void
+    {
+        $this->trace[] = sprintf(
+            '#%d Expander %s failed to match value "%s"',
+            $this->entriesCount(),
+            $name,
+            new SingleLineString((string) new StringConverter($value))
+        );
+
+        $this->trace[] = sprintf(
+            '#%d Expander %s error: %s',
+            $this->entriesCount(),
+            $name,
+            new SingleLineString($error)
+        );
+    }
+
+    public function isEmpty() : bool
+    {
+        return count($this->trace) === 0;
+    }
+
+    public function __toString() : string
+    {
+        return implode("\n", $this->trace);
+    }
+
+    public function raw() : array
+    {
+        return $this->trace;
+    }
+
+    private function entriesCount(): int
+    {
+        return count($this->trace) + 1;
+    }
+}

--- a/src/Backtrace/VoidBacktrace.php
+++ b/src/Backtrace/VoidBacktrace.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Backtrace;
+
+use Coduo\PHPMatcher\Backtrace;
+
+final class VoidBacktrace implements Backtrace
+{
+    public function matcherCanMatch(string $name, $value, bool $result): void
+    {
+    }
+
+    public function matcherEntrance(string $name, $value, $pattern): void
+    {
+    }
+
+    public function matcherSucceed(string $name, $value, $pattern): void
+    {
+    }
+
+    public function matcherFailed(string $name, $value, $pattern, string $error): void
+    {
+    }
+
+    public function expanderEntrance(string $name, $value): void
+    {
+    }
+
+    public function expanderSucceed(string $name, $value): void
+    {
+    }
+
+    public function expanderFailed(string $name, $value, string $error): void
+    {
+    }
+
+    public function isEmpty(): bool
+    {
+        return true;
+    }
+
+    public function __toString(): string
+    {
+        return 'Empty';
+    }
+
+    public function raw(): array
+    {
+        return [];
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,5 +6,5 @@ namespace Coduo\PHPMatcher;
 
 interface Factory
 {
-    public function createMatcher() : Matcher;
+    public function createMatcher(Backtrace $backtrace) : Matcher;
 }

--- a/src/Factory/MatcherFactory.php
+++ b/src/Factory/MatcherFactory.php
@@ -13,11 +13,9 @@ use function class_exists;
 
 final class MatcherFactory implements Factory
 {
-    public function createMatcher() : Matcher
+    public function createMatcher(Backtrace $backtrace) : Matcher
     {
-        $matcherBacktrace = new Backtrace();
-
-        return new Matcher($this->buildMatchers($this->buildParser($matcherBacktrace), $matcherBacktrace), $matcherBacktrace);
+        return new Matcher($this->buildMatchers($this->buildParser($backtrace), $backtrace), $backtrace);
     }
 
     protected function buildMatchers(Parser $parser, Backtrace $backtrace) : Matcher\ChainMatcher

--- a/src/Matcher/Pattern/Expander/Match.php
+++ b/src/Matcher/Pattern/Expander/Match.php
@@ -35,7 +35,7 @@ final class Match implements Matcher\Pattern\PatternExpander
         $this->backtrace->expanderEntrance(self::NAME, $value);
 
         if ($this->matcher === null) {
-            $this->matcher = (new MatcherFactory())->createMatcher();
+            $this->matcher = (new MatcherFactory())->createMatcher($this->backtrace);
         }
 
         $result = $this->matcher->match($value, $this->pattern);

--- a/src/Matcher/Pattern/Expander/Repeat.php
+++ b/src/Matcher/Pattern/Expander/Repeat.php
@@ -83,7 +83,7 @@ final class Repeat implements PatternExpander
         }
 
         $factory = new MatcherFactory();
-        $matcher = $factory->createMatcher();
+        $matcher = $factory->createMatcher($this->backtrace);
 
         if ($this->isScalar) {
             $result = $this->matchScalar($value, $matcher);

--- a/src/PHPMatcher.php
+++ b/src/PHPMatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher;
 
+use Coduo\PHPMatcher\Backtrace\VoidBacktrace;
 use Coduo\PHPMatcher\Factory\MatcherFactory;
 
 final class PHPMatcher
@@ -12,6 +13,18 @@ final class PHPMatcher
      * @var null|Matcher
      */
     private $matcher;
+
+    /**
+     * @var Backtrace
+     */
+    private $backtrace;
+
+    public function __construct(?Backtrace $backtrace = null)
+    {
+        $this->backtrace = $backtrace !== null
+            ? $backtrace
+            : new VoidBacktrace();
+    }
 
     public function match($value, $pattern) : bool
     {
@@ -28,7 +41,7 @@ final class PHPMatcher
      */
     public function backtrace() : Backtrace
     {
-        return $this->getMatcher()->backtrace();
+        return $this->backtrace;
     }
 
     /**
@@ -45,7 +58,7 @@ final class PHPMatcher
     private function getMatcher() : Matcher
     {
         if (null === $this->matcher) {
-            $this->matcher = (new MatcherFactory())->createMatcher();
+            $this->matcher = (new MatcherFactory())->createMatcher($this->backtrace());
         }
 
         return $this->matcher;

--- a/src/PHPUnit/PHPMatcherAssertions.php
+++ b/src/PHPUnit/PHPMatcherAssertions.php
@@ -4,17 +4,28 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\PHPUnit;
 
+use Coduo\PHPMatcher\Backtrace;
 use PHPUnit\Framework\TestCase;
 
 trait PHPMatcherAssertions
 {
-    protected function assertMatchesPattern($pattern, $value, string $message = '') : void
+    /**
+     * @var null|Backtrace
+     */
+    protected $backtrace = null;
+
+    protected function setBacktrace(Backtrace $backtrace) : void
     {
-        TestCase::assertThat($value, self::matchesPattern($pattern), $message);
+        $this->backtrace = $backtrace;
     }
 
-    protected static function matchesPattern($pattern) : PHPMatcherConstraint
+    protected function assertMatchesPattern($pattern, $value, string $message = '') : void
     {
-        return new PHPMatcherConstraint($pattern);
+        TestCase::assertThat($value, self::matchesPattern($pattern, $this->backtrace), $message);
+    }
+
+    protected static function matchesPattern($pattern, ?Backtrace $backtrace = null) : PHPMatcherConstraint
+    {
+        return new PHPMatcherConstraint($pattern, $backtrace);
     }
 }

--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\PHPUnit;
 
+use Coduo\PHPMatcher\Backtrace;
 use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Util\Json;
@@ -29,7 +30,7 @@ final class PHPMatcherConstraint extends Constraint
 
     private $lastValue;
 
-    public function __construct($pattern)
+    public function __construct($pattern, Backtrace $backtrace = null)
     {
         if (!in_array(gettype($pattern), ['string', 'array', 'object'])) {
             throw new LogicException(sprintf('The PHPMatcherConstraint pattern must be a string, closure or an array, %s given.', gettype($pattern)));
@@ -40,7 +41,7 @@ final class PHPMatcherConstraint extends Constraint
         }
 
         $this->pattern = $pattern;
-        $this->matcher = new PHPMatcher();
+        $this->matcher = new PHPMatcher($backtrace);
     }
 
     /**

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests;
 
+use Coduo\PHPMatcher\Backtrace\InMemoryBacktrace;
 use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\TestCase;
 use function file_get_contents;
@@ -17,7 +18,7 @@ final class BacktraceTest extends TestCase
 
     public function setUp() : void
     {
-        $this->matcher = new PHPMatcher();
+        $this->matcher = new PHPMatcher(new InMemoryBacktrace());
     }
 
     public function test_backtrace_in_failed_simple_matching()

--- a/tests/Matcher/ArrayMatcherTest.php
+++ b/tests/Matcher/ArrayMatcherTest.php
@@ -21,7 +21,7 @@ class ArrayMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $backtrace = new Backtrace();
+        $backtrace = new Backtrace\InMemoryBacktrace();
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace));
 
         $matchers = [
@@ -68,7 +68,7 @@ class ArrayMatcherTest extends TestCase
         $matcher = new Matcher\ArrayMatcher(
             new Matcher\ChainMatcher(
                 self::class,
-                $backtrace = new Backtrace(),
+                $backtrace = new Backtrace\InMemoryBacktrace(),
                 [
                     new Matcher\WildcardMatcher($backtrace)
                 ]

--- a/tests/Matcher/BooleanMatcherTest.php
+++ b/tests/Matcher/BooleanMatcherTest.php
@@ -22,7 +22,7 @@ class BooleanMatcherTest extends TestCase
     public function setUp() : void
     {
         $this->matcher = new BooleanMatcher(
-            $backtrace = new Backtrace(),
+            $backtrace = new Backtrace\InMemoryBacktrace(),
             new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace))
         );
     }

--- a/tests/Matcher/CallbackMatcherTest.php
+++ b/tests/Matcher/CallbackMatcherTest.php
@@ -13,7 +13,7 @@ class CallbackMatcherTest extends TestCase
 {
     public function test_positive_can_match()
     {
-        $matcher = new CallbackMatcher(new Backtrace());
+        $matcher = new CallbackMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($matcher->canMatch(function () {
             return true;
         }));
@@ -21,14 +21,14 @@ class CallbackMatcherTest extends TestCase
 
     public function test_negative_can_match()
     {
-        $matcher = new CallbackMatcher(new Backtrace());
+        $matcher = new CallbackMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($matcher->canMatch(new DateTime()));
         $this->assertFalse($matcher->canMatch('SIN'));
     }
 
     public function test_positive_matches()
     {
-        $matcher = new CallbackMatcher(new Backtrace());
+        $matcher = new CallbackMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($matcher->match(2, function ($value) {
             return true;
         }));
@@ -39,7 +39,7 @@ class CallbackMatcherTest extends TestCase
 
     public function test_negative_matches()
     {
-        $matcher = new CallbackMatcher(new Backtrace());
+        $matcher = new CallbackMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($matcher->match(2, function ($value) {
             return false;
         }));

--- a/tests/Matcher/ChainMatcherTest.php
+++ b/tests/Matcher/ChainMatcherTest.php
@@ -35,7 +35,7 @@ class ChainMatcherTest extends TestCase
 
         $this->matcher = new ChainMatcher(
             self::class,
-            new Backtrace(),
+            new Backtrace\InMemoryBacktrace(),
             [
                 $this->firstMatcher,
                 $this->secondMatcher

--- a/tests/Matcher/DoubleMatcherTest.php
+++ b/tests/Matcher/DoubleMatcherTest.php
@@ -22,7 +22,7 @@ class DoubleMatcherTest extends TestCase
     public function setUp() : void
     {
         $this->matcher = new DoubleMatcher(
-            $backtrace = new Backtrace(),
+            $backtrace = new Backtrace\InMemoryBacktrace(),
             new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace))
         );
     }

--- a/tests/Matcher/ExpressionMatcherTest.php
+++ b/tests/Matcher/ExpressionMatcherTest.php
@@ -17,7 +17,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_positive_can_matches($pattern)
     {
-        $matcher = new ExpressionMatcher(new Backtrace());
+        $matcher = new ExpressionMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($matcher->canMatch($pattern));
     }
 
@@ -26,7 +26,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_negative_can_matches($pattern)
     {
-        $matcher = new ExpressionMatcher(new Backtrace());
+        $matcher = new ExpressionMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($matcher->canMatch($pattern));
     }
 
@@ -35,7 +35,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_positive_match($value, $pattern)
     {
-        $matcher = new ExpressionMatcher(new Backtrace());
+        $matcher = new ExpressionMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($matcher->match($value, $pattern));
     }
 
@@ -44,7 +44,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_negative_match($value, $pattern)
     {
-        $matcher = new ExpressionMatcher(new Backtrace());
+        $matcher = new ExpressionMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($matcher->match($value, $pattern));
     }
 
@@ -53,7 +53,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_negative_match_description($value, $pattern, $error)
     {
-        $matcher = new ExpressionMatcher(new Backtrace());
+        $matcher = new ExpressionMatcher(new Backtrace\InMemoryBacktrace());
         $matcher->match($value, $pattern);
         $this->assertEquals($error, $matcher->getError());
     }
@@ -63,7 +63,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_positive_regex_matches($value, $pattern)
     {
-        $matcher = new ExpressionMatcher(new Backtrace());
+        $matcher = new ExpressionMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($matcher->match($value, $pattern));
     }
 
@@ -72,7 +72,7 @@ class ExpressionMatcherTest extends TestCase
      */
     public function test_negative_regex_matches($value, $pattern)
     {
-        $matcher = new ExpressionMatcher(new Backtrace());
+        $matcher = new ExpressionMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($matcher->match($value, $pattern));
     }
 

--- a/tests/Matcher/IntegerMatcherTest.php
+++ b/tests/Matcher/IntegerMatcherTest.php
@@ -22,7 +22,7 @@ class IntegerMatcherTest extends TestCase
     public function setUp() : void
     {
         $this->matcher = new IntegerMatcher(
-            $backtrace = new Backtrace(),
+            $backtrace = new Backtrace\InMemoryBacktrace(),
             new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace))
         );
     }

--- a/tests/Matcher/JsonMatcherTest.php
+++ b/tests/Matcher/JsonMatcherTest.php
@@ -20,7 +20,7 @@ class JsonMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $backtrace = new Backtrace();
+        $backtrace = new Backtrace\InMemoryBacktrace();
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace));
         $scalarMatchers = new Matcher\ChainMatcher(
             self::class,

--- a/tests/Matcher/JsonObjectMatcherTest.php
+++ b/tests/Matcher/JsonObjectMatcherTest.php
@@ -20,7 +20,7 @@ final class JsonObjectMatcherTest extends TestCase
     public function setUp() : void
     {
         $this->matcher = new JsonObjectMatcher(
-            $backtrace = new Backtrace(),
+            $backtrace = new Backtrace\InMemoryBacktrace(),
             new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace))
         );
     }

--- a/tests/Matcher/NullMatcherTest.php
+++ b/tests/Matcher/NullMatcherTest.php
@@ -18,7 +18,7 @@ class NullMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $this->matcher = new NullMatcher(new Backtrace());
+        $this->matcher = new NullMatcher(new Backtrace\InMemoryBacktrace());
     }
 
     /**

--- a/tests/Matcher/NumberMatcherTest.php
+++ b/tests/Matcher/NumberMatcherTest.php
@@ -22,7 +22,7 @@ class NumberMatcherTest extends TestCase
     public function setUp() : void
     {
         $this->matcher = new NumberMatcher(
-            $backtrace = new Backtrace(),
+            $backtrace = new Backtrace\InMemoryBacktrace(),
             new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace))
         );
     }

--- a/tests/Matcher/OrMatcherTest.php
+++ b/tests/Matcher/OrMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\Matcher;
 
+use Coduo\PHPMatcher\Backtrace\VoidBacktrace;
 use Coduo\PHPMatcher\Factory\MatcherFactory;
 use Coduo\PHPMatcher\Matcher;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +19,7 @@ class OrMatcherTest extends TestCase
     public function setUp() : void
     {
         $factory = new MatcherFactory();
-        $this->matcher = $factory->createMatcher();
+        $this->matcher = $factory->createMatcher(new VoidBacktrace());
     }
 
     /**

--- a/tests/Matcher/Pattern/Expander/AfterTest.php
+++ b/tests/Matcher/Pattern/Expander/AfterTest.php
@@ -16,7 +16,7 @@ class AfterTest extends TestCase
     public function test_examples($boundary, $value, $expectedResult)
     {
         $expander = new After($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 
@@ -35,7 +35,7 @@ class AfterTest extends TestCase
     public function test_error_when_matching_fail($boundary, $value, $errorMessage)
     {
         $expander = new After($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/BeforeTest.php
+++ b/tests/Matcher/Pattern/Expander/BeforeTest.php
@@ -16,7 +16,7 @@ class BeforeTest extends TestCase
     public function test_examples($boundary, $value, $expectedResult)
     {
         $expander = new Before($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 
@@ -35,7 +35,7 @@ class BeforeTest extends TestCase
     public function test_error_when_matching_fail($boundary, $value, $errorMessage)
     {
         $expander = new Before($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/ContainsTest.php
+++ b/tests/Matcher/Pattern/Expander/ContainsTest.php
@@ -17,7 +17,7 @@ class ContainsTest extends TestCase
     public function test_matching_values_case_sensitive($needle, $haystack, $expectedResult)
     {
         $expander = new Contains($needle);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($haystack));
     }
 
@@ -37,7 +37,7 @@ class ContainsTest extends TestCase
     public function test_matching_values_case_insensitive($needle, $haystack, $expectedResult)
     {
         $expander = new Contains($needle, true);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($haystack));
     }
 
@@ -57,7 +57,7 @@ class ContainsTest extends TestCase
     public function test_error_when_matching_fail($string, $value, $errorMessage)
     {
         $expander = new Contains($string);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/CountTest.php
+++ b/tests/Matcher/Pattern/Expander/CountTest.php
@@ -17,7 +17,7 @@ class CountTest extends TestCase
     public function test_matching_values($needle, $haystack, $expectedResult)
     {
         $expander = new Count($needle);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($haystack));
     }
 
@@ -35,7 +35,7 @@ class CountTest extends TestCase
     public function test_error_when_matching_fail($boundary, $value, $errorMessage)
     {
         $expander = new Count($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/EndsWithTest.php
+++ b/tests/Matcher/Pattern/Expander/EndsWithTest.php
@@ -17,7 +17,7 @@ class EndsWithTest extends TestCase
     public function test_examples_not_ignoring_case($stringEnding, $value, $expectedResult)
     {
         $expander = new EndsWith($stringEnding);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 
@@ -38,7 +38,7 @@ class EndsWithTest extends TestCase
     public function test_examples_ignoring_case($stringEnding, $value, $expectedResult)
     {
         $expander = new EndsWith($stringEnding, true);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 
@@ -57,7 +57,7 @@ class EndsWithTest extends TestCase
     public function test_error_when_matching_fail($stringBeginning, $value, $errorMessage)
     {
         $expander = new EndsWith($stringBeginning);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/GreaterThanTest.php
+++ b/tests/Matcher/Pattern/Expander/GreaterThanTest.php
@@ -16,7 +16,7 @@ class GreaterThanTest extends TestCase
     public function test_examples($boundary, $value, $expectedResult)
     {
         $expander = new GreaterThan($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 
@@ -37,7 +37,7 @@ class GreaterThanTest extends TestCase
     public function test_error_when_matching_fail($boundary, $value, $errorMessage)
     {
         $expander = new GreaterThan($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/HasPropertyTest.php
+++ b/tests/Matcher/Pattern/Expander/HasPropertyTest.php
@@ -16,7 +16,7 @@ class HasPropertyTest extends TestCase
     public function test_examples($propertyName, $value, $expectedResult)
     {
         $expander = new HasProperty($propertyName);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 

--- a/tests/Matcher/Pattern/Expander/InArrayTest.php
+++ b/tests/Matcher/Pattern/Expander/InArrayTest.php
@@ -17,7 +17,7 @@ class InArrayTest extends TestCase
     public function test_matching_values($needle, $haystack, $expectedResult)
     {
         $expander = new InArray($needle);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($haystack));
     }
 
@@ -36,7 +36,7 @@ class InArrayTest extends TestCase
     public function test_error_when_matching_fail($boundary, $value, $errorMessage)
     {
         $expander = new InArray($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/IsDateTimeTest.php
+++ b/tests/Matcher/Pattern/Expander/IsDateTimeTest.php
@@ -16,7 +16,7 @@ class IsDateTimeTest extends TestCase
     public function test_dates($date, $expectedResult)
     {
         $expander = new IsDateTime();
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($date));
     }
 

--- a/tests/Matcher/Pattern/Expander/IsEmailTest.php
+++ b/tests/Matcher/Pattern/Expander/IsEmailTest.php
@@ -16,7 +16,7 @@ class IsEmailTest extends TestCase
     public function test_emails($email, $expectedResult)
     {
         $expander = new IsEmail();
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($email));
     }
 

--- a/tests/Matcher/Pattern/Expander/IsEmptyTest.php
+++ b/tests/Matcher/Pattern/Expander/IsEmptyTest.php
@@ -16,7 +16,7 @@ class IsEmptyTest extends TestCase
     public function test_is_empty_expander_match($value, $expectedResult)
     {
         $expander = new IsEmpty();
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 

--- a/tests/Matcher/Pattern/Expander/IsIpTest.php
+++ b/tests/Matcher/Pattern/Expander/IsIpTest.php
@@ -16,7 +16,7 @@ class IsIpTest extends TestCase
     public function test_ip($ip, $expected)
     {
         $expander = new IsIp();
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expected, $expander->match($ip));
     }
 

--- a/tests/Matcher/Pattern/Expander/IsNotEmptyTest.php
+++ b/tests/Matcher/Pattern/Expander/IsNotEmptyTest.php
@@ -17,7 +17,7 @@ class IsNotEmptyTest extends TestCase
     public function test_examples_not_ignoring_case($value, $expectedResult)
     {
         $expander = new IsNotEmpty();
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 

--- a/tests/Matcher/Pattern/Expander/IsUrlTest.php
+++ b/tests/Matcher/Pattern/Expander/IsUrlTest.php
@@ -16,7 +16,7 @@ class IsUrlTest extends TestCase
     public function test_urls($url, $expectedResult)
     {
         $expander = new IsUrl();
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($url));
     }
 

--- a/tests/Matcher/Pattern/Expander/LowerThanTest.php
+++ b/tests/Matcher/Pattern/Expander/LowerThanTest.php
@@ -16,7 +16,7 @@ class LowerThanTest extends TestCase
     public function test_examples($boundary, $value, $expectedResult)
     {
         $expander = new LowerThan($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 
@@ -36,7 +36,7 @@ class LowerThanTest extends TestCase
     public function test_error_when_matching_fail($boundary, $value, $errorMessage)
     {
         $expander = new LowerThan($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/MatchRegexTest.php
+++ b/tests/Matcher/Pattern/Expander/MatchRegexTest.php
@@ -17,7 +17,7 @@ class MatchRegexTest extends TestCase
     public function test_match_expander($expectedResult, $expectedError, $pattern, $value)
     {
         $expander = new MatchRegex($pattern);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
         $this->assertSame($expectedError, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/NotContainsTest.php
+++ b/tests/Matcher/Pattern/Expander/NotContainsTest.php
@@ -17,7 +17,7 @@ class NotContainsTest extends TestCase
     public function test_matching_values_case_sensitive($needle, $haystack, $expectedResult)
     {
         $expander = new NotContains($needle);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($haystack));
     }
 
@@ -37,7 +37,7 @@ class NotContainsTest extends TestCase
     public function test_matching_values_case_insensitive($needle, $haystack, $expectedResult)
     {
         $expander = new NotContains($needle, true);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($haystack));
     }
 
@@ -57,7 +57,7 @@ class NotContainsTest extends TestCase
     public function test_error_when_matching_fail($string, $value, $errorMessage)
     {
         $expander = new NotContains($string);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/OneOfTest.php
+++ b/tests/Matcher/Pattern/Expander/OneOfTest.php
@@ -30,7 +30,7 @@ class OneOfTest extends TestCase
 
     public function test_positive_match()
     {
-        $backtrace = new Backtrace();
+        $backtrace = new Backtrace\InMemoryBacktrace();
         $contains = new Contains('lorem');
         $contains->setBacktrace($backtrace);
         $contains1 = new Contains('test');
@@ -40,14 +40,14 @@ class OneOfTest extends TestCase
             $contains,
             $contains1
         );
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
 
         $this->assertTrue($expander->match('lorem ipsum'));
     }
 
     public function test_negative_match()
     {
-        $backtrace = new Backtrace();
+        $backtrace = new Backtrace\InMemoryBacktrace();
         $contains = new Contains('lorem');
         $contains->setBacktrace($backtrace);
         $contains1 = new Contains('test');

--- a/tests/Matcher/Pattern/Expander/OptionalTest.php
+++ b/tests/Matcher/Pattern/Expander/OptionalTest.php
@@ -16,7 +16,7 @@ class OptionalTest extends TestCase
     public function test_optional_expander_match($value, $expectedResult)
     {
         $expander = new Optional();
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 

--- a/tests/Matcher/Pattern/Expander/RepeatTest.php
+++ b/tests/Matcher/Pattern/Expander/RepeatTest.php
@@ -16,7 +16,7 @@ class RepeatTest extends TestCase
     public function test_matching_values($needle, $haystack, $expectedResult, $isStrict = true)
     {
         $expander = new Repeat($needle, $isStrict);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($haystack));
     }
 
@@ -54,7 +54,7 @@ class RepeatTest extends TestCase
     public function test_error_when_matching_fail($boundary, $value, $errorMessage)
     {
         $expander = new Repeat($boundary);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/Pattern/Expander/StartsWithTest.php
+++ b/tests/Matcher/Pattern/Expander/StartsWithTest.php
@@ -17,7 +17,7 @@ class StartsWithTest extends TestCase
     public function test_examples_not_ignoring_case($stringBeginning, $value, $expectedResult)
     {
         $expander = new StartsWith($stringBeginning);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertEquals($expectedResult, $expander->match($value));
     }
 
@@ -38,7 +38,7 @@ class StartsWithTest extends TestCase
     public function test_examples_ignoring_case($stringBeginning, $value)
     {
         $expander = new StartsWith($stringBeginning, true);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($expander->match($value));
     }
 
@@ -57,7 +57,7 @@ class StartsWithTest extends TestCase
     public function test_error_when_matching_fail($stringBeginning, $value, $errorMessage)
     {
         $expander = new StartsWith($stringBeginning);
-        $expander->setBacktrace(new Backtrace());
+        $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($expander->match($value));
         $this->assertEquals($errorMessage, $expander->getError());
     }

--- a/tests/Matcher/ScalarMatcherTest.php
+++ b/tests/Matcher/ScalarMatcherTest.php
@@ -16,7 +16,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_positive_can_matches($pattern)
     {
-        $matcher = new ScalarMatcher(new Backtrace());
+        $matcher = new ScalarMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($matcher->canMatch($pattern));
     }
 
@@ -25,7 +25,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_negative_can_matches($pattern)
     {
-        $matcher = new ScalarMatcher(new Backtrace());
+        $matcher = new ScalarMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($matcher->canMatch($pattern));
     }
 
@@ -34,7 +34,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_positive_matches($value, $pattern)
     {
-        $matcher = new ScalarMatcher(new Backtrace());
+        $matcher = new ScalarMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($matcher->match($value, $pattern));
     }
 
@@ -43,7 +43,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_negative_matches($value, $pattern)
     {
-        $matcher = new ScalarMatcher(new Backtrace());
+        $matcher = new ScalarMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($matcher->match($value, $pattern));
     }
 
@@ -52,7 +52,7 @@ class ScalarMatcherTest extends TestCase
      */
     public function test_negative_match_description($value, $pattern, $error)
     {
-        $matcher = new ScalarMatcher(new Backtrace());
+        $matcher = new ScalarMatcher(new Backtrace\InMemoryBacktrace());
         $matcher->match($value, $pattern);
         $this->assertEquals($error, $matcher->getError());
     }

--- a/tests/Matcher/StringMatcherTest.php
+++ b/tests/Matcher/StringMatcherTest.php
@@ -21,7 +21,7 @@ class StringMatcherTest extends TestCase
     public function setUp() : void
     {
         $this->matcher = new StringMatcher(
-            $backtrace = new Backtrace(),
+            $backtrace = new Backtrace\InMemoryBacktrace(),
             new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace))
         );
     }

--- a/tests/Matcher/TextMatcherTest.php
+++ b/tests/Matcher/TextMatcherTest.php
@@ -20,7 +20,7 @@ class TextMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $backtrace = new Backtrace();
+        $backtrace = new Backtrace\InMemoryBacktrace();
 
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace));
         $scalarMatchers = new Matcher\ChainMatcher(

--- a/tests/Matcher/UuidMatcherTest.php
+++ b/tests/Matcher/UuidMatcherTest.php
@@ -21,7 +21,7 @@ class UuidMatcherTest extends TestCase
     public function setUp() : void
     {
         $this->matcher = new UuidMatcher(
-            $backtrace = new Backtrace(),
+            $backtrace = new Backtrace\InMemoryBacktrace(),
             new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace))
         );
     }

--- a/tests/Matcher/WildcardMatcherTest.php
+++ b/tests/Matcher/WildcardMatcherTest.php
@@ -16,7 +16,7 @@ class WildcardMatcherTest extends TestCase
      */
     public function test_positive_match($pattern)
     {
-        $matcher = new WildcardMatcher(new Backtrace());
+        $matcher = new WildcardMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($matcher->match('*', $pattern));
     }
 
@@ -25,13 +25,13 @@ class WildcardMatcherTest extends TestCase
      */
     public function test_positive_can_match($pattern)
     {
-        $matcher = new WildcardMatcher(new Backtrace());
+        $matcher = new WildcardMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertTrue($matcher->canMatch($pattern));
     }
 
     public function test_negative_can_match()
     {
-        $matcher = new WildcardMatcher(new Backtrace());
+        $matcher = new WildcardMatcher(new Backtrace\InMemoryBacktrace());
         $this->assertFalse($matcher->canMatch('*'));
     }
 

--- a/tests/Matcher/XmlMatcherTest.php
+++ b/tests/Matcher/XmlMatcherTest.php
@@ -19,7 +19,7 @@ class XmlMatcherTest extends TestCase
 
     public function setUp() : void
     {
-        $backtrace = new Backtrace();
+        $backtrace = new Backtrace\InMemoryBacktrace();
         $parser = new Parser(new Lexer(), new Parser\ExpanderInitializer($backtrace));
         $scalarMatchers = new Matcher\ChainMatcher(
             self::class,

--- a/tests/PHPUnit/PHPMatcherAssertionsTest.php
+++ b/tests/PHPUnit/PHPMatcherAssertionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Coduo\PHPMatcher\Tests\PHPUnit;
 
+use Coduo\PHPMatcher\Backtrace\InMemoryBacktrace;
 use Coduo\PHPMatcher\PHPUnit\PHPMatcherAssertions;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
@@ -35,9 +36,34 @@ class PHPMatcherAssertionsTest extends TestCase
          * #...
          * #66 Matcher Coduo\PHPMatcher\Matcher error: Value {"foo":"bar"} does not match pattern {"foo":"@integer@"}.
          */
-        $this->expectExceptionMessageMatches("/Failed asserting that '{\"foo\":\"bar\"}' matches given pattern.\nPattern: '{\"foo\": \"@integer@\"}'\nError: Value {\"foo\":\"bar\"} does not match pattern {\"foo\":\"@integer@\"}\nBacktrace: \n(.*)/");
+        $this->expectExceptionMessageMatches("/Failed asserting that '{\"foo\":\"bar\"}' matches given pattern.\nPattern: '{\"foo\": \"@integer@\"}'\nError: Value {\"foo\":\"bar\"} does not match pattern {\"foo\":\"@integer@\"}\nBacktrace: \nEmpty/");
 
         $this->assertMatchesPattern('{"foo": "@integer@"}', json_encode(['foo' => 'bar']));
+    }
+
+    public function test_it_throws_an_expectation_failed_exception_if_a_value_does_not_match_the_pattern_with_backtrace()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->setBacktrace($backtrace = new InMemoryBacktrace());
+
+        /*
+         * Expected console output:
+         *
+         * Failed asserting that '{"foo":"bar"}' matches given pattern.
+         * Pattern: '{"foo": "@integer@"}'
+         * Error: Value {"foo":"bar"} does not match pattern {"foo":"@integer@"}
+         * Backtrace:
+         * #1 Matcher Coduo\PHPMatcher\Matcher matching value "{"foo":"bar"}" with "{"foo":"@integer@"}" pattern
+         * #2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) matching value "{"foo":"bar"}" with "{"foo":"@integer@"}" pattern
+         * #3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "{"foo":"@integer@"}"
+         * #...
+         * #66 Matcher Coduo\PHPMatcher\Matcher error: Value {"foo":"bar"} does not match pattern {"foo":"@integer@"}.
+         */
+        $this->expectExceptionMessageMatches("/Failed asserting that '{\"foo\":\"bar\"}' matches given pattern.\nPattern: '{\"foo\": \"@integer@\"}'\nError: Value {\"foo\":\"bar\"} does not match pattern {\"foo\":\"@integer@\"}\nBacktrace: \n/");
+
+        $this->assertMatchesPattern('{"foo": "@integer@"}', json_encode(['foo' => 'bar']));
+        $this->assertFalse($backtrace->isEmpty());
     }
 
     public function test_it_creates_a_constraint_for_stubs()

--- a/tests/ParserSyntaxErrorTest.php
+++ b/tests/ParserSyntaxErrorTest.php
@@ -19,7 +19,7 @@ class ParserSyntaxErrorTest extends TestCase
 
     public function setUp() : void
     {
-        $this->parser = new Parser(new Lexer(), new Parser\ExpanderInitializer(new Backtrace()));
+        $this->parser = new Parser(new Lexer(), new Parser\ExpanderInitializer(new Backtrace\InMemoryBacktrace()));
     }
 
     public function test_unexpected_statement_at_type_position()

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -19,7 +19,7 @@ class ParserTest extends TestCase
 
     public function setUp() : void
     {
-        $this->parser = new Parser(new Lexer(), new Parser\ExpanderInitializer(new Backtrace()));
+        $this->parser = new Parser(new Lexer(), new Parser\ExpanderInitializer(new Backtrace\InMemoryBacktrace()));
     }
 
     public function test_simple_pattern_without_expanders()


### PR DESCRIPTION
Resolves #201 

Blacfire profiles, as expected VoidBacktrace is way faster. 
* `VoidBacktrace` - https://blackfire.io/profiles/7fe767de-c234-4d33-addd-ba217d8c6ce4/graph
* `InMemoryBacktrace` - https://blackfire.io/profiles/bf6d1854-44c5-4174-a842-de226f87092f/graph

Both profiles executed against following code:

```php
// $backtrace = new VoidBacktrace();
// $backtrace = new InMemoryBacktrace();

$matcher = (new MatcherFactory())->createMatcher($backtrace);

$value = [
    'users' => [
        [
            'id' => 1,
            'firstName' => 'Norbert',
            'lastName' => 'Orzechowicz',
            'enabled' => true,
        ],
        [
            'id' => 2,
            'firstName' => 'Michał',
            'lastName' => 'Dąbrowski',
            'enabled' => true,
        ],
    ],
    'readyToUse' => true,
    'data' => new stdClass(),
];

$pattern = [
    'users' => [
        [
            'id' => '@integer@',
            'firstName' => '@string@',
            'lastName' => 'Orzechowicz',
            'enabled' => '@boolean@',
        ],
        [
            'id' => '@integer@',
            'firstName' => '@string@',
            'lastName' => 'Dąbrowski',
            'enabled' => '@boolean@',
        ],
    ],
    'readyToUse' => true,
    'data' => '@wildcard@',
];


for ($i = 0; $i < 100; $i++) {
    $matcher->match($value, $pattern);
}
```