### PR TITLE
Fixed JSON handling in PHPMatcherConstraint

### DIFF
--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -61,33 +61,34 @@ final class PHPMatcherConstraint extends Constraint
      */
     protected function fail($other, $description, ComparisonFailure $comparisonFailure = null) : void
     {
-        if (null === $comparisonFailure
-            && \is_string($other)
-            && \is_string($this->pattern)
-            && \class_exists(Json::class)
-        ) {
-            [$error] = Json::canonicalize($other);
+        parent::fail($other, $description, $comparisonFailure ?? $this->createComparisonFailure($other));
+    }
 
-            if ($error) {
-                parent::fail($other, $description);
-            }
-
-            [$error] = Json::canonicalize($this->pattern);
-
-            if ($error) {
-                parent::fail($other, $description);
-            }
-
-            $comparisonFailure = new ComparisonFailure(
-                \json_decode($this->pattern),
-                \json_decode($other),
-                Json::prettify($this->pattern),
-                Json::prettify($other),
-                false,
-                'Failed asserting that the pattern matches the given value.'
-            );
+    private function createComparisonFailure($other) : ?ComparisonFailure
+    {
+        if (!\is_string($other) || !\is_string($this->pattern) || !\class_exists(Json::class)) {
+            return null;
         }
 
-        parent::fail($other, $description, $comparisonFailure);
+        [$error, $otherJson] = Json::canonicalize($other);
+
+        if ($error) {
+            return null;
+        }
+
+        [$error, $patternJson] = Json::canonicalize($this->pattern);
+
+        if ($error) {
+            return null;
+        }
+
+        return new ComparisonFailure(
+            \json_decode($this->pattern),
+            \json_decode($other),
+            Json::prettify($patternJson),
+            Json::prettify($otherJson),
+            false,
+            'Failed asserting that the pattern matches the given value.'
+        );
     }
 }

--- a/tests/PHPUnit/PHPMatcherConstraintTest.php
+++ b/tests/PHPUnit/PHPMatcherConstraintTest.php
@@ -7,6 +7,7 @@ namespace Coduo\PHPMatcher\Tests\PHPUnit;
 use Coduo\PHPMatcher\PHPUnit\PHPMatcherConstraint;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 
 class PHPMatcherConstraintTest extends TestCase
@@ -48,6 +49,48 @@ class PHPMatcherConstraintTest extends TestCase
         $constraint = new PHPMatcherConstraint('@string@');
 
         $this->assertFalse($constraint->evaluate(42));
+    }
+
+    public function test_expected_as_string_is_sorted() : void
+    {
+        $constraint = new PHPMatcherConstraint('{"b": 2, "a": 1}');
+
+        try {
+            $constraint->evaluate('null');
+
+            $this->fail();
+        } catch (ExpectationFailedException $exception) {
+            $this->assertSame(
+                <<<'JSON'
+{
+    "a": 1,
+    "b": 2
+}
+JSON,
+                $exception->getComparisonFailure()->getExpectedAsString()
+            );
+        }
+    }
+
+    public function test_actual_as_string_is_sorted() : void
+    {
+        $constraint = new PHPMatcherConstraint('{}');
+
+        try {
+            $constraint->evaluate('{"b": 2, "a": 1}');
+
+            $this->fail();
+        } catch (ExpectationFailedException $exception) {
+            $this->assertSame(
+                <<<'JSON'
+{
+    "a": 1,
+    "b": 2
+}
+JSON,
+                $exception->getComparisonFailure()->getActualAsString()
+            );
+        }
     }
 
     public function test_that_pattern_could_be_an_array() : void

--- a/tests/PHPUnit/PHPMatcherConstraintTest.php
+++ b/tests/PHPUnit/PHPMatcherConstraintTest.php
@@ -66,7 +66,8 @@ class PHPMatcherConstraintTest extends TestCase
     "a": 1,
     "b": 2
 }
-JSON,
+JSON
+                ,
                 $exception->getComparisonFailure()->getExpectedAsString()
             );
         }
@@ -87,7 +88,8 @@ JSON,
     "a": 1,
     "b": 2
 }
-JSON,
+JSON
+                ,
                 $exception->getComparisonFailure()->getActualAsString()
             );
         }


### PR DESCRIPTION
JSON values are supposed to be canonicalized, but it does not work, because the new json string is not assigned via array unpacking. This PR fixes the issue.

I also fixed the absence of `return` after `parent::fail($other, $description);` by moving comparison failure construction to its own method and adding early returns.