### PR TITLE
Simplify failure description returned by PHPMatcherConstraint

### DIFF
--- a/src/PHPUnit/PHPMatcherConstraint.php
+++ b/src/PHPUnit/PHPMatcherConstraint.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\PHPUnit;
 
 use Coduo\PHPMatcher\Backtrace;
+use Coduo\PHPMatcher\Backtrace\VoidBacktrace;
 use Coduo\PHPMatcher\PHPMatcher;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Util\Json;
@@ -42,10 +43,13 @@ final class PHPMatcherConstraint extends Constraint
 
     protected function failureDescription($other) : string
     {
-        return parent::failureDescription($other)
-            . "\nPattern: " . $this->exporter()->export($this->pattern)
-            . "\nError: " . $this->matcher->error()
-            . "\nBacktrace: \n" . $this->matcher->backtrace();
+        $errorDescription = $this->matcher->error() ?: 'Value does not match given pattern';
+        $backtrace = $this->matcher->backtrace();
+
+        return $backtrace instanceof VoidBacktrace
+            ? $errorDescription
+            : $errorDescription
+                . "\nBacktrace:\n" . $this->matcher->backtrace();
     }
 
     protected function matches($value) : bool

--- a/tests/PHPUnit/PHPMatcherAssertionsTest.php
+++ b/tests/PHPUnit/PHPMatcherAssertionsTest.php
@@ -25,11 +25,7 @@ class PHPMatcherAssertionsTest extends TestCase
         } catch (\Exception $e) {
             $this->assertSame(
                 <<<'ERROR'
-Failed asserting that '{"foo":"bar"}' matches given pattern.
-Pattern: '{"foo": "@integer@"}'
-Error: Value "bar" does not match pattern "@integer@" at path: "[foo]"
-Backtrace: 
-Empty.
+Failed asserting that Value "bar" does not match pattern "@integer@" at path: "[foo]".
 ERROR,
                 $e->getMessage()
             );
@@ -45,10 +41,8 @@ ERROR,
         } catch (\Exception $e) {
             $this->assertSame(
                 <<<ERROR
-Failed asserting that '{"foo":"bar"}' matches given pattern.
-Pattern: '{"foo": "@integer@"}'
-Error: Value "bar" does not match pattern "@integer@" at path: "[foo]"
-Backtrace: 
+Failed asserting that Value "bar" does not match pattern "@integer@" at path: "[foo]"
+Backtrace:
 #1 Matcher Coduo\PHPMatcher\Matcher matching value "{"foo":"bar"}" with "{"foo":"@integer@"}" pattern
 #2 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) matching value "{"foo":"bar"}" with "{"foo":"@integer@"}" pattern
 #3 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "{"foo":"@integer@"}"
@@ -150,7 +144,7 @@ ERROR,
          *  #...
          *  #35 Matcher Coduo\PHPMatcher\Matcher error: integer "42" is not a valid string.
          */
-        $this->expectExceptionMessageMatches("/Expectation failed for method name is \"getTitle\" when invoked zero or more times\nParameter 0 for invocation stdClass::getTitle\(42\) does not match expected value.\nFailed asserting that 42 matches given pattern.\nPattern: '@string@'\nError: integer \"42\" is not a valid string.\nBacktrace: \n(.*)/");
+        $this->expectExceptionMessageMatches("/Expectation failed for method name is \"getTitle\" when invoked zero or more times\nParameter 0 for invocation stdClass::getTitle\(42\) does not match expected value.\nFailed asserting that integer \"42\" is not a valid string../");
 
         $mock = $this->getMockBuilder('stdClass')
             ->setMethods(['getTitle'])

--- a/tests/PHPUnit/PHPMatcherConstraintTest.php
+++ b/tests/PHPUnit/PHPMatcherConstraintTest.php
@@ -34,7 +34,7 @@ class PHPMatcherConstraintTest extends TestCase
     public function test_it_sets_a_failure_description_if_not_given() : void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessageMatches('/Failed asserting that 42 matches given pattern(.*)/');
+        $this->expectExceptionMessageMatches('/Failed asserting that integer "42" is not a valid string../');
 
         $constraint = new PHPMatcherConstraint('@string@');
 

--- a/tests/PHPUnit/PHPMatcherTestCaseTest.php
+++ b/tests/PHPUnit/PHPMatcherTestCaseTest.php
@@ -17,7 +17,7 @@ class PHPMatcherTestCaseTest extends PHPMatcherTestCase
     public function test_it_throws_an_expectation_failed_exception_if_a_value_does_not_match_the_pattern() : void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessageMatches("/Failed asserting that '{\"foo\":\"bar\"}' matches given pattern(.*)/");
+        $this->expectExceptionMessageMatches('/Failed asserting that Value "bar" does not match pattern "@integer@" at path: "\\[foo\\]"./');
 
         $this->assertMatchesPattern('{"foo": "@integer@"}', \json_encode(['foo' => 'bar']));
     }
@@ -25,7 +25,7 @@ class PHPMatcherTestCaseTest extends PHPMatcherTestCase
     public function test_it_creates_a_constraint_for_stubs() : void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessageMatches('/Failed asserting that 42 matches given pattern(.*)/');
+        $this->expectExceptionMessageMatches('/Failed asserting that integer "42" is not a valid string../');
 
         $mock = $this->getMockBuilder('stdClass')
             ->setMethods(['getTitle'])


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Omit pattern and empty backtrace in failure description returned by PHPMatcherConstraint</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This PR simplifies the failure description returned by the `PHPMatcherConstraint` class. The intention of the change is to make the actual error easier to find. We are happily using the library for testing an API with big responses. Prepending the error with the given value and the pattern makes it hard to sport the actual error in such a usecase. 

The PR changes the output when running the following example test cases like this:
```php
use Coduo\PHPMatcher\PHPUnit\PHPMatcherConstraint;
use PHPUnit\Framework\TestCase;

class PatternTest extends TestCase
{
    public function testPattern(): void
    {
        $pattern = <<<EOF
            {
                "name": "@string@",
                "description": "test-1"
            }
EOF;

        $value = <<<EOF
            {
                "name": "test-2",
                "description": "test-2"
            }
EOF;

        TestCase::assertThat(
            $value,
            new PHPMatcherConstraint($pattern)
        );
    }
}
```

**Old output**:
```
1) Namespace\PatternTest::testPattern
Failed asserting that '            {\n
                "name": "test-2",\n
                "description": "test-2"\n
            }' matches given pattern.
Pattern: '            {\n
                "name": "@string@",\n
                "description": "test-1"\n
            }'
Error: Value "test-2" does not match pattern "test-1" at path: "[description]"
Backtrace: 
Empty.
--- Expected
+++ Actual
@@ @@
 {
-    "description": "test-1",
-    "name": "@string@"
+    "description": "test-2",
+    "name": "test-2"
 }
```

**New output**:
```
1) Namespace\PatternTest::testPattern
Failed asserting that Value "test-2" does not match pattern "test-1" at path: "[description]".
--- Expected
+++ Actual
@@ @@
 {
-    "description": "test-1",
-    "name": "@string@"
+    "description": "test-2",
+    "name": "test-2"
 }
```