### PR TITLE
allow aeon-php/calendar ^0.17.0 and ^0.18.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-filter": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "aeon-php/calendar": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0",
+        "aeon-php/calendar": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0",
         "coduo/php-to-string": "^3",
         "doctrine/lexer": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-filter": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "aeon-php/calendar": "^0.14.0 || ^0.15.0 || ^0.16.0",
+        "aeon-php/calendar": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0",
         "coduo/php-to-string": "^3",
         "doctrine/lexer": "^1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ec6bfcdc0590b92a6b2b3f67f3f1adf",
+    "content-hash": "b6e7d4891ceaeb22f9b218dbe5776739",
     "packages": [
         {
             "name": "aeon-php/calendar",
-            "version": "0.16.1",
+            "version": "0.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aeon-php/calendar.git",
-                "reference": "9509656c6b01024aad6158628fc8c950f9cf1199"
+                "reference": "a35eff5a6a3700ab2294e0ccdfa7e98de8641a5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aeon-php/calendar/zipball/9509656c6b01024aad6158628fc8c950f9cf1199",
-                "reference": "9509656c6b01024aad6158628fc8c950f9cf1199",
+                "url": "https://api.github.com/repos/aeon-php/calendar/zipball/a35eff5a6a3700ab2294e0ccdfa7e98de8641a5f",
+                "reference": "a35eff5a6a3700ab2294e0ccdfa7e98de8641a5f",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
             ],
             "support": {
                 "issues": "https://github.com/aeon-php/calendar/issues",
-                "source": "https://github.com/aeon-php/calendar/tree/0.16.1"
+                "source": "https://github.com/aeon-php/calendar/tree/0.17.0"
             },
             "funding": [
                 {
@@ -59,7 +59,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-23T08:58:57+00:00"
+            "time": "2021-04-24T16:16:37+00:00"
         },
         {
             "name": "coduo/php-to-string",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6e7d4891ceaeb22f9b218dbe5776739",
+    "content-hash": "5c20cbfa0e98863a26e463745a8bbc7d",
     "packages": [
         {
             "name": "aeon-php/calendar",
-            "version": "0.17.0",
+            "version": "0.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aeon-php/calendar.git",
-                "reference": "a35eff5a6a3700ab2294e0ccdfa7e98de8641a5f"
+                "reference": "61c1582fac59275287cbe3f256ac86226ddce3d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aeon-php/calendar/zipball/a35eff5a6a3700ab2294e0ccdfa7e98de8641a5f",
-                "reference": "a35eff5a6a3700ab2294e0ccdfa7e98de8641a5f",
+                "url": "https://api.github.com/repos/aeon-php/calendar/zipball/61c1582fac59275287cbe3f256ac86226ddce3d1",
+                "reference": "61c1582fac59275287cbe3f256ac86226ddce3d1",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
             ],
             "support": {
                 "issues": "https://github.com/aeon-php/calendar/issues",
-                "source": "https://github.com/aeon-php/calendar/tree/0.17.0"
+                "source": "https://github.com/aeon-php/calendar/tree/0.18.0"
             },
             "funding": [
                 {
@@ -59,7 +59,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-04-24T16:16:37+00:00"
+            "time": "2021-05-01T20:04:37+00:00"
         },
         {
             "name": "coduo/php-to-string",


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>allow aeon-php/calendar to be used in ^0.17.0 and ^0.180</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

changes [here](https://github.com/aeon-php/calendar/compare/0.16.4...0.18.0)