### PR TITLE
Fix UUID pattern

### DIFF
--- a/src/Matcher/UuidMatcher.php
+++ b/src/Matcher/UuidMatcher.php
@@ -18,7 +18,7 @@ final class UuidMatcher extends Matcher
     /**
      * @var string
      */
-    public const UUID_PATTERN = '[\da-f]{8}-[\da-f]{4}-[1-6][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}';
+    public const UUID_PATTERN = '[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}';
 
     /**
      * @var string

--- a/tests/Matcher/UuidMatcherTest.php
+++ b/tests/Matcher/UuidMatcherTest.php
@@ -30,6 +30,7 @@ class UuidMatcherTest extends TestCase
             ['9f4db639-0e87-4367-9beb-d64e3f42ae18', '@uuid@'],
             ['1f2b1a18-81a0-5685-bca7-f23022ed7c7b', '@uuid@'],
             ['1ebb5050-b028-616a-9180-0a00ac070060', '@uuid@'],
+            ['00000000-0000-0000-0000-000000000000', '@uuid@'],
         ];
     }
 
@@ -53,7 +54,6 @@ class UuidMatcherTest extends TestCase
             ['9f4db6390e8743679bebd64e3f42ae18', '@uuid@'],
             ['9f4db6390e87-4367-9beb-d64e-3f42ae18', '@uuid@'],
             ['9f4db639-0e87-4367-9beb-d64e3f42ae1g', '@uuid@'],
-            ['9f4db639-0e87-0367-9beb-d64e3f42ae18', '@uuid@'],
         ];
     }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Changed</h4>
  <ul id="changed">
      <li>Fixed UUID pattern</li>
  </ul> 
</div>
<hr/>

<h2>Description</h2>

The currently UUID isn't exactly a general UUID matcher, but a variant-specific matcher.  

For example, the [NIL UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier#Nil_UUID) doesn't match, although it's a valid, UUID as defined in the UUID spec. Also, restricting the version and variant isn't exactly right, since [using other hex digit is valid](https://www.uuidtools.com/decode), meaning the version and variant are unknown. Even the most used [UUID library in the PHP ecosystem](https://github.com/ramsey/uuid/blob/a180174b0e7d9083c1868c52202d35129d11b2c2/src/Lazy/LazyUuidFromString.php#L57), or the native UUID in Java, doesn't impose such restrictions.