### PR TITLE
Using assertSame to make assert equals restricted

### DIFF
--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -87,7 +87,7 @@ final class BacktraceTest extends TestCase
         // Uncomment when backtrace logic changes, run tests and then commit again.
         \file_put_contents(__DIR__ . '/BacktraceTest/failed_complex_matching_expected_trace.txt', (string) $this->matcher->backtrace());
 
-        $this->assertEquals(
+        $this->assertSame(
             \file_get_contents(__DIR__ . '/BacktraceTest/failed_complex_matching_expected_trace.txt'),
             (string) $this->matcher->backtrace()
         );
@@ -143,7 +143,7 @@ final class BacktraceTest extends TestCase
         // Uncomment when backtrace logic changes, run tests and then commit again.
         \file_put_contents(__DIR__ . '/BacktraceTest/succeed_complex_matching_expected_trace.txt', (string) $this->matcher->backtrace());
 
-        $this->assertEquals(
+        $this->assertSame(
             \file_get_contents(__DIR__ . '/BacktraceTest/succeed_complex_matching_expected_trace.txt'),
             (string) $this->matcher->backtrace()
         );

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -86,8 +86,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_STRING);
-        $this->assertEquals($lexer->lookahead['value'], \trim(\trim($value, "'"), '"'));
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_STRING);
+        $this->assertSame($lexer->lookahead['value'], \trim(\trim($value, "'"), '"'));
     }
 
     /**
@@ -98,8 +98,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_NUMBER);
-        $this->assertEquals($expectedValue, $lexer->lookahead['value']);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_NUMBER);
+        $this->assertSame($expectedValue, $lexer->lookahead['value']);
     }
 
     /**
@@ -110,8 +110,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_BOOLEAN);
-        $this->assertEquals($lexer->lookahead['value'], $expectedValue);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_BOOLEAN);
+        $this->assertSame($lexer->lookahead['value'], $expectedValue);
     }
 
     /**
@@ -122,7 +122,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_NULL);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_NULL);
         $this->assertNull($lexer->lookahead['value']);
     }
 
@@ -134,7 +134,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_NONE);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_NONE);
     }
 
     public function test_close_parenthesis() : void
@@ -142,7 +142,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput(')');
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_CLOSE_PARENTHESIS);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_CLOSE_PARENTHESIS);
     }
 
     public function test_close_open_brace() : void
@@ -150,7 +150,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput('{');
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_OPEN_CURLY_BRACE);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_OPEN_CURLY_BRACE);
     }
 
     public function test_close_curly_brace() : void
@@ -158,7 +158,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput('}');
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_CLOSE_CURLY_BRACE);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_CLOSE_CURLY_BRACE);
     }
 
     public function test_colon() : void
@@ -166,7 +166,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput(':');
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_COLON);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_COLON);
     }
 
     public function test_comma() : void
@@ -174,7 +174,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput(',');
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_COMMA);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_COMMA);
     }
 
     /**
@@ -185,8 +185,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_TYPE_PATTERN);
-        $this->assertEquals($lexer->lookahead['value'], \trim($value, '@'));
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_TYPE_PATTERN);
+        $this->assertSame($lexer->lookahead['value'], \trim($value, '@'));
     }
 
     /**
@@ -197,8 +197,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertEquals($lexer->lookahead['type'], Lexer::T_EXPANDER_NAME);
-        $this->assertEquals($lexer->lookahead['value'], $expectedTokenValue);
+        $this->assertSame($lexer->lookahead['type'], Lexer::T_EXPANDER_NAME);
+        $this->assertSame($lexer->lookahead['value'], $expectedTokenValue);
     }
 
     public function test_ignore_whitespaces_between_parenthesis() : void
@@ -207,7 +207,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput("@type@.expander( 'arg1',    2    ,'arg3',4)");
 
-        $this->assertEquals($expectedTokens, $this->collectTokens($lexer));
+        $this->assertSame($expectedTokens, $this->collectTokens($lexer));
     }
 
     /**

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -77,7 +77,7 @@ class ParserTest extends TestCase
     {
         $pattern = '@type@';
 
-        $this->assertEquals('type', $this->parser->getAST($pattern)->getType());
+        $this->assertSame('type', (string) $this->parser->getAST($pattern)->getType());
         $this->assertFalse($this->parser->getAST($pattern)->hasExpanders());
     }
 
@@ -85,16 +85,16 @@ class ParserTest extends TestCase
     {
         $pattern = '@type@.expander()';
 
-        $this->assertEquals('type', $this->parser->getAST($pattern)->getType());
+        $this->assertSame('type', (string) $this->parser->getAST($pattern)->getType());
         $expanders = $this->parser->getAST($pattern)->getExpanders();
-        $this->assertEquals('expander', $expanders[0]->getName());
+        $this->assertSame('expander', $expanders[0]->getName());
         $this->assertFalse($expanders[0]->hasArguments());
     }
 
     public function test_single_expander_with_arguments() : void
     {
         $pattern = "@type@.expander('arg1', 2, 2.24, \"arg3\")";
-        $this->assertEquals('type', $this->parser->getAST($pattern)->getType());
+        $this->assertSame('type', (string) $this->parser->getAST($pattern)->getType());
         $expanders = $this->parser->getAST($pattern)->getExpanders();
         $expectedArguments = [
             'arg1',
@@ -102,7 +102,7 @@ class ParserTest extends TestCase
             2.24,
             'arg3',
         ];
-        $this->assertEquals($expectedArguments, $expanders[0]->getArguments());
+        $this->assertSame($expectedArguments, $expanders[0]->getArguments());
     }
 
     public function test_many_expanders() : void
@@ -115,14 +115,14 @@ class ParserTest extends TestCase
         ];
 
         $expanders = $this->parser->getAST($pattern)->getExpanders();
-        $this->assertEquals('type', $this->parser->getAST($pattern)->getType());
-        $this->assertEquals('expander', $expanders[0]->getName());
-        $this->assertEquals('expander1', $expanders[1]->getName());
-        $this->assertEquals('expander', $expanders[2]->getName());
+        $this->assertSame('type', (string) $this->parser->getAST($pattern)->getType());
+        $this->assertSame('expander', $expanders[0]->getName());
+        $this->assertSame('expander1', $expanders[1]->getName());
+        $this->assertSame('expander', $expanders[2]->getName());
 
-        $this->assertEquals($expanderArguments[0], $expanders[0]->getArguments());
-        $this->assertEquals($expanderArguments[1], $expanders[1]->getArguments());
-        $this->assertEquals($expanderArguments[2], $expanders[2]->getArguments());
+        $this->assertSame($expanderArguments[0], $expanders[0]->getArguments());
+        $this->assertSame($expanderArguments[1], $expanders[1]->getArguments());
+        $this->assertSame($expanderArguments[2], $expanders[2]->getArguments());
     }
 
     /**
@@ -131,7 +131,7 @@ class ParserTest extends TestCase
     public function test_single_array_argument_with_string_key_value($pattern, $expectedArgument) : void
     {
         $expanders = $this->parser->getAST($pattern)->getExpanders();
-        $this->assertEquals($expectedArgument, $expanders[0]->getArguments());
+        $this->assertSame($expectedArgument, $expanders[0]->getArguments());
     }
 
     public function test_expanders_that_takes_other_expanders_as_arguments() : void


### PR DESCRIPTION
## Change Log

**Changed**
- the unit tests about assert equals.

<hr/>

## Description

- Using `assertSame` to replace the `assertEquals` and it can make assert equals restricted.