### PR TITLE
Doctrine Lexer upgraded to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-simplexml": "*",
         "aeon-php/calendar": "^1.0",
         "coduo/php-to-string": "^3",
-        "doctrine/lexer": "^1.0||^2.0"
+        "doctrine/lexer": "^3.0"
     },
     "require-dev": {
         "ext-pcov": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5142ce7b11400d82acfe46a10ca2586",
+    "content-hash": "0dc48a144278c53610245f0db0a3ae3f",
     "packages": [
         {
             "name": "aeon-php/calendar",
@@ -110,76 +110,28 @@
             "time": "2023-03-28T10:10:37+00:00"
         },
         {
-            "name": "doctrine/deprecations",
-            "version": "1.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
-                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
-            },
-            "suggest": {
-                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
-            "homepage": "https://www.doctrine-project.org/",
-            "support": {
-                "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.2"
-            },
-            "time": "2023-09-27T20:04:15+00:00"
-        },
-        {
             "name": "doctrine/lexer",
-            "version": "2.1.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124"
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
                 "shasum": ""
             },
             "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^10",
-                "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.5",
                 "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^4.11 || ^5.0"
+                "vimeo/psalm": "^5.21"
             },
             "type": "library",
             "autoload": {
@@ -216,7 +168,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/2.1.0"
+                "source": "https://github.com/doctrine/lexer/tree/3.0.1"
             },
             "funding": [
                 {
@@ -232,7 +184,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-14T08:49:07+00:00"
+            "time": "2024-02-05T11:56:58+00:00"
         }
     ],
     "packages-dev": [
@@ -2529,5 +2481,5 @@
     "platform-dev": {
         "ext-pcov": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -138,22 +138,18 @@ final class Lexer extends AbstractLexer
         }
 
         if ($this->isBooleanToken($value)) {
-            $value = \strtolower($value) === 'true';
+            $value = \strtolower($value);
 
             return self::T_BOOLEAN;
         }
 
         if ($this->isNullToken($value)) {
-            $value = null;
+            $value = \strtolower($value);
 
             return self::T_NULL;
         }
 
         if (\is_numeric($value)) {
-            if (\is_string($value)) {
-                $value = (\strpos($value, '.') === false) ? (int) $value : (float) $value;
-            }
-
             return self::T_NUMBER;
         }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -8,6 +8,7 @@ use Coduo\PHPMatcher\Exception\Exception;
 use Coduo\PHPMatcher\Exception\PatternException;
 use Coduo\PHPMatcher\Matcher\Pattern;
 use Coduo\PHPMatcher\Parser\ExpanderInitializer;
+use Doctrine\Common\Lexer\Token;
 
 final class Parser
 {
@@ -66,8 +67,8 @@ final class Parser
 
         $pattern = null;
 
-        if ($this->lexer->lookahead['type'] == Lexer::T_TYPE_PATTERN) {
-            $pattern = new AST\Pattern(new AST\Type($this->lexer->lookahead['value']));
+        if ($this->lexer->lookahead->type == Lexer::T_TYPE_PATTERN) {
+            $pattern = new AST\Pattern(new AST\Type($this->lexer->lookahead->value));
         } else {
             throw PatternException::syntaxError($this->unexpectedSyntaxError($this->lexer->lookahead, '@type@ pattern'));
         }
@@ -119,23 +120,19 @@ final class Parser
 
     private function getExpanderName() : string
     {
-        if ($this->lexer->lookahead['type'] !== Lexer::T_EXPANDER_NAME) {
-            throw PatternException::syntaxError($this->unexpectedSyntaxError($this->lexer->lookahead, '.expanderName(args) definition'));
+        $lookahead = $this->lexer->lookahead;
+
+        if ($lookahead === null) {
+            throw PatternException::syntaxError($this->unexpectedSyntaxError($lookahead, '.expanderName(args) definition'));
         }
 
-        $expander = $this->lexer->lookahead['value'];
-
-        if ($expander === null) {
-            throw PatternException::syntaxError($this->unexpectedSyntaxError($this->lexer->lookahead, '.expanderName(args) definition'));
+        if ($lookahead->type !== Lexer::T_EXPANDER_NAME) {
+            throw PatternException::syntaxError($this->unexpectedSyntaxError($lookahead, '.expanderName(args) definition'));
         }
 
         $this->lexer->moveNext();
 
-        if (\is_int($expander)) {
-            return (string) $expander;
-        }
-
-        return $expander;
+        return $lookahead->value;
     }
 
     /**
@@ -144,8 +141,9 @@ final class Parser
     private function addArgumentValues(AST\Expander $expander) : void
     {
         while (($argument = $this->getNextArgumentValue()) !== null) {
-            $argument = ($argument === self::NULL_VALUE) ? null : $argument;
-            $expander->addArgument($argument);
+            $coercedArgument = $this->coerceArgumentValue($argument);
+
+            $expander->addArgument($coercedArgument);
 
             if (!$this->lexer->isNextToken(Lexer::T_COMMA)) {
                 break;
@@ -157,6 +155,30 @@ final class Parser
                 throw PatternException::syntaxError($this->unexpectedSyntaxError($this->lexer->lookahead, 'string, number, boolean or null argument'));
             }
         }
+    }
+
+    private function coerceArgumentValue(mixed $argument) : mixed
+    {
+        $coercedArgument = $argument;
+        if (\is_string($argument)) {
+            $lowercaseArgument = \strtolower($argument);
+            if ($lowercaseArgument === self::NULL_VALUE) {
+                $coercedArgument = null;
+            } else if ($lowercaseArgument === 'true') {
+                $coercedArgument = true;
+            } else if ($lowercaseArgument === 'false') {
+                $coercedArgument = false;
+            } else if (\is_numeric($argument)) {
+                $coercedArgument = (\strpos($argument, '.') === false) ? (int) $argument : (float) $argument;
+            }
+        } elseif (\is_array($argument)) {
+            $coercedArgument = [];
+            foreach ($argument as $key => $arg) {
+                $coercedArgument[$key] = $this->coerceArgumentValue($arg);
+            }
+        }
+
+        return $coercedArgument;
     }
 
     /**
@@ -187,8 +209,8 @@ final class Parser
             throw PatternException::syntaxError($this->unexpectedSyntaxError($this->lexer->lookahead, 'string, number, boolean or null argument'));
         }
 
-        $tokenType = $this->lexer->lookahead['type'];
-        $argument = $this->lexer->lookahead['value'];
+        $tokenType = $this->lexer->lookahead->type;
+        $argument = $this->lexer->lookahead->value;
         $this->lexer->moveNext();
 
         if ($tokenType === Lexer::T_NULL) {
@@ -258,15 +280,15 @@ final class Parser
     }
 
     /**
-     * @param mixed $unexpectedToken
+     * @param ?Token<Lexer::T_*, string> $unexpectedToken
      * @param string $expected
      */
     private function unexpectedSyntaxError($unexpectedToken, string $expected = null) : string
     {
-        $tokenPos = (isset($unexpectedToken['position'])) ? $unexpectedToken['position'] : '-1';
+        $tokenPos = $unexpectedToken !== null ? $unexpectedToken->position : '-1';
         $message  = \sprintf('line 0, col %d: Error: ', $tokenPos);
         $message .= (isset($expected)) ? \sprintf('Expected "%s", got ', $expected) : 'Unexpected';
-        $message .= \sprintf('"%s"', $unexpectedToken['value']);
+        $message .= \sprintf('"%s"', $unexpectedToken->value);
 
         return $message;
     }
@@ -278,7 +300,8 @@ final class Parser
      */
     private function unexpectedEndOfString(string $expected = null) : void
     {
-        $tokenPos = (isset($this->lexer->token['position'])) ? $this->lexer->token['position'] + \strlen((string) $this->lexer->token['value']) : '-1';
+        $tokenPos = (isset($this->lexer->token->position))
+            ? $this->lexer->token->position + \strlen((string) $this->lexer->token->value) : '-1';
         $message  = \sprintf('line 0, col %d: Error: ', $tokenPos);
         $message .= (isset($expected)) ? \sprintf('Expected "%s", got end of string.', $expected) : 'Unexpected';
         $message .= 'end of string';

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -160,19 +160,22 @@ final class Parser
     private function coerceArgumentValue(mixed $argument) : mixed
     {
         $coercedArgument = $argument;
+
         if (\is_string($argument)) {
             $lowercaseArgument = \strtolower($argument);
+
             if ($lowercaseArgument === self::NULL_VALUE) {
                 $coercedArgument = null;
-            } else if ($lowercaseArgument === 'true') {
+            } elseif ($lowercaseArgument === 'true') {
                 $coercedArgument = true;
-            } else if ($lowercaseArgument === 'false') {
+            } elseif ($lowercaseArgument === 'false') {
                 $coercedArgument = false;
-            } else if (\is_numeric($argument)) {
+            } elseif (\is_numeric($argument)) {
                 $coercedArgument = (\strpos($argument, '.') === false) ? (int) $argument : (float) $argument;
             }
         } elseif (\is_array($argument)) {
             $coercedArgument = [];
+
             foreach ($argument as $key => $arg) {
                 $coercedArgument[$key] = $this->coerceArgumentValue($arg);
             }

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -20,20 +20,20 @@ class LexerTest extends TestCase
     public static function validNumberValuesProvider()
     {
         return [
-            ['125', 125],
-            ['12.15', 12.15],
-            ['-10', -10],
-            ['-1.24', -1.24],
+            ['125', '125'],
+            ['12.15', '12.15'],
+            ['-10', '-10'],
+            ['-1.24', '-1.24'],
         ];
     }
 
     public static function validBooleanValuesProvider()
     {
         return [
-            ['true', true],
-            ['false', false],
-            ['TRUE', true],
-            ['fAlSe', false],
+            ['true', 'true'],
+            ['false', 'false'],
+            ['TRUE', 'true'],
+            ['fAlSe', 'false'],
         ];
     }
 
@@ -86,8 +86,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_STRING);
-        $this->assertSame($lexer->lookahead['value'], \trim(\trim($value, "'"), '"'));
+        $this->assertSame($lexer->lookahead->type, Lexer::T_STRING);
+        $this->assertSame($lexer->lookahead->value, \trim(\trim($value, "'"), '"'));
     }
 
     /**
@@ -98,8 +98,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_NUMBER);
-        $this->assertSame($expectedValue, $lexer->lookahead['value']);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_NUMBER);
+        $this->assertSame($expectedValue, $lexer->lookahead->value);
     }
 
     /**
@@ -110,8 +110,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_BOOLEAN);
-        $this->assertSame($lexer->lookahead['value'], $expectedValue);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_BOOLEAN);
+        $this->assertSame($lexer->lookahead->value, $expectedValue);
     }
 
     /**
@@ -122,8 +122,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_NULL);
-        $this->assertNull($lexer->lookahead['value']);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_NULL);
+        $this->assertSame('null', $lexer->lookahead->value);
     }
 
     /**
@@ -134,7 +134,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_NONE);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_NONE);
     }
 
     public function test_close_parenthesis() : void
@@ -142,7 +142,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput(')');
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_CLOSE_PARENTHESIS);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_CLOSE_PARENTHESIS);
     }
 
     public function test_close_open_brace() : void
@@ -150,7 +150,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput('{');
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_OPEN_CURLY_BRACE);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_OPEN_CURLY_BRACE);
     }
 
     public function test_close_curly_brace() : void
@@ -158,7 +158,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput('}');
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_CLOSE_CURLY_BRACE);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_CLOSE_CURLY_BRACE);
     }
 
     public function test_colon() : void
@@ -166,7 +166,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput(':');
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_COLON);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_COLON);
     }
 
     public function test_comma() : void
@@ -174,7 +174,7 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput(',');
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_COMMA);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_COMMA);
     }
 
     /**
@@ -185,8 +185,8 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_TYPE_PATTERN);
-        $this->assertSame($lexer->lookahead['value'], \trim($value, '@'));
+        $this->assertSame($lexer->lookahead->type, Lexer::T_TYPE_PATTERN);
+        $this->assertSame($lexer->lookahead->value, \trim($value, '@'));
     }
 
     /**
@@ -197,13 +197,13 @@ class LexerTest extends TestCase
         $lexer = new Lexer();
         $lexer->setInput($value);
         $lexer->moveNext();
-        $this->assertSame($lexer->lookahead['type'], Lexer::T_EXPANDER_NAME);
-        $this->assertSame($lexer->lookahead['value'], $expectedTokenValue);
+        $this->assertSame($lexer->lookahead->type, Lexer::T_EXPANDER_NAME);
+        $this->assertSame($lexer->lookahead->value, $expectedTokenValue);
     }
 
     public function test_ignore_whitespaces_between_parenthesis() : void
     {
-        $expectedTokens = ['type', 'expander', 'arg1', ',', 2, ',', 'arg3', ',', 4, ')'];
+        $expectedTokens = ['type', 'expander', 'arg1', ',', '2', ',', 'arg3', ',', '4', ')'];
         $lexer = new Lexer();
         $lexer->setInput("@type@.expander( 'arg1',    2    ,'arg3',4)");
 
@@ -220,7 +220,7 @@ class LexerTest extends TestCase
         $tokens = [];
 
         while ($lexer->moveNext()) {
-            $tokens[] = $lexer->lookahead['value'];
+            $tokens[] = $lexer->lookahead->value;
         }
 
         return $tokens;


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Support for doctrine/lexer 3</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li></li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li></li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Support for doctrine/lexer 1 and 2</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>
#473

I believe Lexer class is considered internal so I changed its interface and now it changes values by reference only to strings. It will help to adhere to doctrine/lexer interface of the Token class.
We can coerce values from Lexer into internal representation (actually we already have an element of the coercion with null value)