### PR TITLE
Fix After/Before expanders error message when date/time is equal to boundary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-filter": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "aeon-php/calendar": "^1.0",
+        "aeon-php/calendar": "^1.0.6",
         "coduo/php-to-string": "^3",
         "doctrine/lexer": "^3.0"
     },
@@ -29,6 +29,7 @@
         "openlss/lib-array2xml": "^1.0",
         "symfony/expression-language": "^2.3|^3.0|^4.0|^5.0|^6.0",
         "symfony/cache": "^2.3|^3.0|^4.0|^5.0|^6.0",
+        "nikic/php-parser": "^4.18",
         "symfony/var-exporter": "^2.3|^3.0|^4.0|^5.0|^6.0"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0dc48a144278c53610245f0db0a3ae3f",
+    "content-hash": "9f6892aa271f73695c240225d1bb3d0a",
     "packages": [
         {
             "name": "aeon-php/calendar",
@@ -249,21 +249,21 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.18.0",
+            "version": "v4.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
+                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
+                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
@@ -299,9 +299,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
             },
-            "time": "2023-12-10T21:03:43+00:00"
+            "time": "2024-03-17T08:10:35+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -358,20 +358,21 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -412,9 +413,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -469,23 +476,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.10",
+            "version": "10.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "599109c8ca6bae97b23482d557d2874c25a65e59"
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/599109c8ca6bae97b23482d557d2874c25a65e59",
-                "reference": "599109c8ca6bae97b23482d557d2874c25a65e59",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1",
                 "phpunit/php-file-iterator": "^4.0",
                 "phpunit/php-text-template": "^3.0",
@@ -535,7 +542,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.10"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.14"
             },
             "funding": [
                 {
@@ -543,7 +550,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-11T06:28:43+00:00"
+            "time": "2024-03-12T15:33:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -790,16 +797,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.2",
+            "version": "10.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5aedff46afba98dddecaa12349ec044d9103d4fe"
+                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5aedff46afba98dddecaa12349ec044d9103d4fe",
-                "reference": "5aedff46afba98dddecaa12349ec044d9103d4fe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/547d314dc24ec1e177720d45c6263fb226cc2ae3",
+                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3",
                 "shasum": ""
             },
             "require": {
@@ -871,7 +878,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.20"
             },
             "funding": [
                 {
@@ -887,7 +894,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-05T14:54:33+00:00"
+            "time": "2024-04-24T06:32:35+00:00"
         },
         {
             "name": "psr/cache",
@@ -1043,16 +1050,16 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
@@ -1087,7 +1094,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -1095,7 +1103,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:15+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -1287,20 +1295,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68cfb347a44871f01e33ab0ef8215966432f6957",
-                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -1309,7 +1317,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.1-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1333,7 +1341,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.1.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -1341,20 +1349,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-28T11:50:59+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.3",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
@@ -1362,12 +1370,12 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.0",
-                "symfony/process": "^4.2 || ^5"
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1400,7 +1408,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -1408,20 +1416,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-01T07:48:21+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.0.1",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
@@ -1436,7 +1444,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1464,7 +1472,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
             },
             "funding": [
                 {
@@ -1472,20 +1480,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-11T05:39:26+00:00"
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.1",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc"
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64f51654862e0f5e318db7e9dcc2292c63cdbddc",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
                 "shasum": ""
             },
             "require": {
@@ -1542,7 +1550,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
             },
             "funding": [
                 {
@@ -1550,20 +1558,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-24T13:22:09+00:00"
+            "time": "2024-03-02T07:17:12+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
@@ -1597,14 +1605,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
@@ -1612,24 +1620,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-19T07:19:23+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/649e40d279e243d985aa8fb6e74dd5bb28dc185d",
-                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -1662,7 +1670,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -1670,7 +1678,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T09:25:50+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1958,16 +1966,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.4.0",
+            "version": "v6.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "ac2d25f97b17eec6e19760b6b9962a4f7c44356a"
+                "reference": "b59bbf9c093b592d77110f9ee70c74dff89294cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/ac2d25f97b17eec6e19760b6b9962a4f7c44356a",
-                "reference": "ac2d25f97b17eec6e19760b6b9962a4f7c44356a",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/b59bbf9c093b592d77110f9ee70c74dff89294cb",
+                "reference": "b59bbf9c093b592d77110f9ee70c74dff89294cb",
                 "shasum": ""
             },
             "require": {
@@ -2034,7 +2042,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.4.0"
+                "source": "https://github.com/symfony/cache/tree/v6.4.6"
             },
             "funding": [
                 {
@@ -2050,20 +2058,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-24T19:28:07+00:00"
+            "time": "2024-03-27T13:27:42+00:00"
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v3.4.0",
+            "version": "v3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "1d74b127da04ffa87aa940abe15446fa89653778"
+                "reference": "2c9db6509a1b21dad229606897639d3284f54b2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/1d74b127da04ffa87aa940abe15446fa89653778",
-                "reference": "1d74b127da04ffa87aa940abe15446fa89653778",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/2c9db6509a1b21dad229606897639d3284f54b2a",
+                "reference": "2c9db6509a1b21dad229606897639d3284f54b2a",
                 "shasum": ""
             },
             "require": {
@@ -2110,7 +2118,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.4.0"
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.4.2"
             },
             "funding": [
                 {
@@ -2126,7 +2134,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-25T12:52:38+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2197,16 +2205,16 @@
         },
         {
             "name": "symfony/expression-language",
-            "version": "v6.4.0",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/expression-language.git",
-                "reference": "6c8b12f1e5ee5d91b812fb8628fca86e2fe5d152"
+                "reference": "b4a4ae33fbb33a99d23c5698faaecadb76ad0fe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/expression-language/zipball/6c8b12f1e5ee5d91b812fb8628fca86e2fe5d152",
-                "reference": "6c8b12f1e5ee5d91b812fb8628fca86e2fe5d152",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/b4a4ae33fbb33a99d23c5698faaecadb76ad0fe4",
+                "reference": "b4a4ae33fbb33a99d23c5698faaecadb76ad0fe4",
                 "shasum": ""
             },
             "require": {
@@ -2241,7 +2249,7 @@
             "description": "Provides an engine that can compile and evaluate expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/expression-language/tree/v6.4.0"
+                "source": "https://github.com/symfony/expression-language/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -2257,25 +2265,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-27T06:52:43+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.4.0",
+            "version": "v3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
+                "reference": "11bbf19a0fb7b36345861e85c5768844c552906e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
-                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/11bbf19a0fb7b36345861e85c5768844c552906e",
+                "reference": "11bbf19a0fb7b36345861e85c5768844c552906e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/container": "^2.0"
+                "psr/container": "^1.1|^2.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -2323,7 +2331,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.4.2"
             },
             "funding": [
                 {
@@ -2339,20 +2347,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-30T20:28:31+00:00"
+            "time": "2023-12-19T21:51:00+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.4.1",
+            "version": "v6.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "2d08ca6b9cc704dce525615d1e6d1788734f36d9"
+                "reference": "20888cf4d11de203613515cf0587828bf5af0fe7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/2d08ca6b9cc704dce525615d1e6d1788734f36d9",
-                "reference": "2d08ca6b9cc704dce525615d1e6d1788734f36d9",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/20888cf4d11de203613515cf0587828bf5af0fe7",
+                "reference": "20888cf4d11de203613515cf0587828bf5af0fe7",
                 "shasum": ""
             },
             "require": {
@@ -2360,6 +2368,8 @@
                 "symfony/deprecation-contracts": "^2.5|^3"
             },
             "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
                 "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
@@ -2398,7 +2408,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.4.1"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.6"
             },
             "funding": [
                 {
@@ -2414,20 +2424,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-30T10:32:10+00:00"
+            "time": "2024-03-20T21:07:14+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -2456,7 +2466,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -2464,7 +2474,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-20T00:12:19+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],
@@ -2481,5 +2491,5 @@
     "platform-dev": {
         "ext-pcov": "*"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Matcher/Pattern/Expander/After.php
+++ b/src/Matcher/Pattern/Expander/After.php
@@ -5,139 +5,34 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
 
 use Aeon\Calendar\Gregorian\DateTime;
-use Aeon\Calendar\Gregorian\Time;
 use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
 use Coduo\ToString\StringConverter;
 
 final class After implements PatternExpander
 {
-    use BacktraceBehavior;
+    use DateTimeComparisonTrait;
 
     /**
      * @var string
      */
     public const NAME = 'after';
 
-    private ?DateTime $boundaryDateTime;
-
-    private ?Time $boundaryTime;
-
-    private ?string $error;
-
-    public function __construct($boundary)
+    protected function handleComparison(string $value, DateTime $datetime) : bool
     {
-        $this->error = null;
-        $this->boundaryTime = null;
-        $this->boundaryDateTime = null;
-
-        if (!\is_string($boundary)) {
-            $this->error = \sprintf('After expander require "string", got "%s".', new StringConverter($boundary));
-        }
-
-        try {
-            $this->boundaryDateTime = DateTime::fromString($boundary);
-        } catch (\Exception $exception) {
-            try {
-                $this->boundaryTime = Time::fromString($boundary);
-            } catch (\Exception $exception) {
-                throw new \InvalidArgumentException(\sprintf('Boundary value "%s" is not a valid date, date time or time.', new StringConverter($boundary)));
-            }
-        }
-    }
-
-    public static function is(string $name) : bool
-    {
-        return self::NAME === $name;
-    }
-
-    public function match($value) : bool
-    {
-        $this->backtrace->expanderEntrance(self::NAME, $value);
-
-        if (!\is_string($value)) {
-            $this->error = \sprintf('After expander require "string", got "%s".', new StringConverter($value));
+        if ($datetime->isBeforeOrEqualTo($this->boundary)) {
+            $this->error = \sprintf('Value "%s" is before or equal to "%s".', new StringConverter($value), new StringConverter($this->boundary));
             $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
 
             return false;
         }
 
-        if ($this->boundaryDateTime instanceof DateTime) {
-            return $this->compareDateTime($value);
-        }
+        $this->backtrace->expanderSucceed(self::NAME, $value);
 
-        return $this->compareTime($value);
+        return true;
     }
 
-    public function getError() : ?string
+    protected static function getName() : string
     {
-        return $this->error;
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return bool
-     */
-    private function compareDateTime(string $value) : bool
-    {
-        try {
-            $datetime = DateTime::fromString($value);
-
-            if ($datetime->isBefore($this->boundaryDateTime)) {
-                $this->error = \sprintf('Value "%s" is after "%s".', new StringConverter($value), new StringConverter($this->boundaryDateTime));
-                $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
-
-                return false;
-            }
-
-            $result = $datetime->isAfter($this->boundaryDateTime);
-
-            if ($result) {
-                $this->backtrace->expanderSucceed(self::NAME, $value);
-            } else {
-                $this->backtrace->expanderFailed(self::NAME, $value, '');
-            }
-
-            return $result;
-        } catch (\Exception $e) {
-            $this->error = \sprintf('Value "%s" is not a valid date.', new StringConverter($value));
-            $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
-
-            return false;
-        }
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return bool
-     */
-    private function compareTime(string $value) : bool
-    {
-        try {
-            $datetime = Time::fromString($value);
-
-            if ($datetime->isLessThan($this->boundaryTime)) {
-                $this->error = \sprintf('Value "%s" is after "%s".', new StringConverter($value), new StringConverter($this->boundaryTime));
-                $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
-
-                return false;
-            }
-
-            $result = $datetime->isGreaterThan($this->boundaryTime);
-
-            if ($result) {
-                $this->backtrace->expanderSucceed(self::NAME, $value);
-            } else {
-                $this->backtrace->expanderFailed(self::NAME, $value, '');
-            }
-
-            return $result;
-        } catch (\Exception $e) {
-            $this->error = \sprintf('Value "%s" is not a valid time.', new StringConverter($value));
-            $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
-
-            return false;
-        }
+        return self::NAME;
     }
 }

--- a/src/Matcher/Pattern/Expander/Before.php
+++ b/src/Matcher/Pattern/Expander/Before.php
@@ -5,139 +5,34 @@ declare(strict_types=1);
 namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
 
 use Aeon\Calendar\Gregorian\DateTime;
-use Aeon\Calendar\Gregorian\Time;
 use Coduo\PHPMatcher\Matcher\Pattern\PatternExpander;
 use Coduo\ToString\StringConverter;
 
 final class Before implements PatternExpander
 {
-    use BacktraceBehavior;
+    use DateTimeComparisonTrait;
 
     /**
      * @var string
      */
     public const NAME = 'before';
 
-    private ?DateTime $boundaryDateTime;
-
-    private ?Time $boundaryTime;
-
-    private ?string $error;
-
-    public function __construct(string $boundary)
+    protected function handleComparison(string $value, DateTime $datetime) : bool
     {
-        $this->error = null;
-        $this->boundaryTime = null;
-        $this->boundaryDateTime = null;
-
-        if (!\is_string($boundary)) {
-            throw new \InvalidArgumentException(\sprintf('Before expander require "string", got "%s".', new StringConverter($boundary)));
-        }
-
-        try {
-            $this->boundaryDateTime = DateTime::fromString($boundary);
-        } catch (\Exception $exception) {
-            try {
-                $this->boundaryTime = Time::fromString($boundary);
-            } catch (\Exception $exception) {
-                throw new \InvalidArgumentException(\sprintf('Boundary value "%s" is not a valid date, date time or time.', new StringConverter($boundary)));
-            }
-        }
-    }
-
-    public static function is(string $name) : bool
-    {
-        return self::NAME === $name;
-    }
-
-    public function match($value) : bool
-    {
-        $this->backtrace->expanderEntrance(self::NAME, $value);
-
-        if (!\is_string($value)) {
-            $this->error = \sprintf('Before expander require "string", got "%s".', new StringConverter($value));
+        if ($datetime->isAfterOrEqualTo($this->boundary)) {
+            $this->error = \sprintf('Value "%s" is after or equal to "%s".', $value, new StringConverter($this->boundary));
             $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
 
             return false;
         }
 
-        if ($this->boundaryDateTime instanceof DateTime) {
-            return $this->compareDateTime($value);
-        }
+        $this->backtrace->expanderSucceed(self::NAME, $value);
 
-        return $this->compareTime($value);
+        return true;
     }
 
-    public function getError() : ?string
+    protected static function getName() : string
     {
-        return $this->error;
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return bool
-     */
-    private function compareDateTime(string $value) : bool
-    {
-        try {
-            $datetime = DateTime::fromString($value);
-
-            if ($datetime->isAfter($this->boundaryDateTime)) {
-                $this->error = \sprintf('Value "%s" is before "%s".', new StringConverter($value), new StringConverter($this->boundaryDateTime));
-                $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
-
-                return false;
-            }
-
-            $result = $datetime->isBefore($this->boundaryDateTime);
-
-            if ($result) {
-                $this->backtrace->expanderSucceed(self::NAME, $value);
-            } else {
-                $this->backtrace->expanderFailed(self::NAME, $value, '');
-            }
-
-            return $result;
-        } catch (\Exception $e) {
-            $this->error = \sprintf('Value "%s" is not a valid date.', new StringConverter($value));
-            $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
-
-            return false;
-        }
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return bool
-     */
-    private function compareTime(string $value) : bool
-    {
-        try {
-            $datetime = Time::fromString($value);
-
-            if ($datetime->isGreaterThan($this->boundaryTime)) {
-                $this->error = \sprintf('Value "%s" is before "%s".', new StringConverter($value), new StringConverter($this->boundaryTime));
-                $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
-
-                return false;
-            }
-
-            $result = $datetime->isLessThan($this->boundaryTime);
-
-            if ($result) {
-                $this->backtrace->expanderSucceed(self::NAME, $value);
-            } else {
-                $this->backtrace->expanderFailed(self::NAME, $value, '');
-            }
-
-            return $result;
-        } catch (\Exception $e) {
-            $this->error = \sprintf('Value "%s" is not a valid time.', new StringConverter($value));
-            $this->backtrace->expanderFailed(self::NAME, $value, $this->error);
-
-            return false;
-        }
+        return self::NAME;
     }
 }

--- a/src/Matcher/Pattern/Expander/DateTimeComparisonTrait.php
+++ b/src/Matcher/Pattern/Expander/DateTimeComparisonTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Coduo\PHPMatcher\Matcher\Pattern\Expander;
+
+use Aeon\Calendar\Gregorian\DateTime;
+use Coduo\ToString\StringConverter;
+
+trait DateTimeComparisonTrait
+{
+    use BacktraceBehavior;
+
+    private readonly DateTime $boundary;
+
+    private ?string $error = null;
+
+    public function __construct(string $boundary)
+    {
+        if (!\is_string($boundary)) {
+            throw new \InvalidArgumentException(\sprintf('Before expander require "string", got "%s".', new StringConverter($boundary)));
+        }
+
+        try {
+            $this->boundary = DateTime::fromString($boundary);
+        } catch (\Exception $exception) {
+            throw new \InvalidArgumentException(\sprintf('Boundary value "%s" is not a valid date, date time or time.', new StringConverter($boundary)));
+        }
+    }
+
+    public static function is(string $name) : bool
+    {
+        return static::getName() === $name;
+    }
+
+    public function match($value) : bool
+    {
+        $this->backtrace->expanderEntrance(static::getName(), $value);
+
+        if (!\is_string($value)) {
+            $this->error = \sprintf('%s expander require "string", got "%s".', static::getName(), new StringConverter($value));
+            $this->backtrace->expanderFailed(static::getName(), $value, $this->error);
+
+            return false;
+        }
+
+        return $this->compare($value);
+    }
+
+    public function getError() : ?string
+    {
+        return $this->error;
+    }
+
+    abstract protected static function getName() : string;
+
+    /**
+     * @param string $value raw value
+     * @param DateTime $datetime value converted in DateTime object
+     */
+    abstract protected function handleComparison(string $value, DateTime $datetime) : bool;
+
+    private function compare(string $value) : bool
+    {
+        try {
+            $datetime = DateTime::fromString($value);
+        } catch (\Exception $e) {
+            $this->error = \sprintf('Value "%s" is not a valid date, date time or time.', new StringConverter($value));
+            $this->backtrace->expanderFailed(static::getName(), $value, $this->error);
+
+            return false;
+        }
+
+        return $this->handleComparison($value, $datetime);
+    }
+}

--- a/tests/BacktraceTest/failed_complex_matching_expected_trace.txt
+++ b/tests/BacktraceTest/failed_complex_matching_expected_trace.txt
@@ -90,231 +90,38 @@
 #90 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
 #91 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
 #92 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@integer@"
-#93 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
-#94 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "131" with "@integer@" pattern
-#95 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "131" with "@integer@" pattern
-#96 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "131" with "@integer@" pattern
-#97 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "131" with "@integer@" pattern
-#98 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Norbert"
-#99 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Norbert" with "Norbert" pattern
-#100 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Norbert"
-#101 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Norbert"
-#102 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Norbert" with "Norbert" pattern
-#103 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Norbert"
-#104 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Norbert"
-#105 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Norbert"
-#106 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Norbert"
-#107 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Norbert"
-#108 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Norbert"
-#109 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Norbert"
-#110 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Norbert"
-#111 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Norbert"
-#112 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Norbert"
-#113 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Norbert"
-#114 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Norbert"
-#115 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Norbert"
-#116 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Norbert" with "Norbert" pattern
-#117 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Norbert" with "Norbert" pattern
-#118 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Norbert" with "Norbert" pattern
-#119 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Orzechowicz"
-#120 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Orzechowicz" with "Orzechowicz" pattern
-#121 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Orzechowicz"
-#122 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Orzechowicz"
-#123 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Orzechowicz" with "Orzechowicz" pattern
-#124 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Orzechowicz"
-#125 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Orzechowicz"
-#126 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Orzechowicz"
-#127 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Orzechowicz"
-#128 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Orzechowicz"
-#129 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Orzechowicz"
-#130 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Orzechowicz"
-#131 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Orzechowicz"
-#132 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Orzechowicz"
-#133 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Orzechowicz"
-#134 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Orzechowicz"
-#135 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Orzechowicz"
-#136 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Orzechowicz"
-#137 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
-#138 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#139 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#140 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@boolean@"
-#141 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "true" with "@boolean@" pattern
-#142 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@boolean@"
-#143 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@boolean@"
-#144 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "true" with "@boolean@" pattern
-#145 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@boolean@"
-#146 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@boolean@"
-#147 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@boolean@"
-#148 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@boolean@"
-#149 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@boolean@"
-#150 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can match pattern "@boolean@"
-#151 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher matching value "true" with "@boolean@" pattern
-#152 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher successfully matched value "true" with "@boolean@" pattern
-#153 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "true" with "@boolean@" pattern
-#154 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "true" with "@boolean@" pattern
-#155 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@array@.isEmpty()"
-#156 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(0)" with "@array@.isEmpty()" pattern
-#157 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@array@.isEmpty()"
-#158 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@array@.isEmpty()"
-#159 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(0)" with "@array@.isEmpty()" pattern
-#160 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@array@.isEmpty()"
-#161 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@array@.isEmpty()"
-#162 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@array@.isEmpty()"
-#163 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@array@.isEmpty()"
-#164 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@array@.isEmpty()"
-#165 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "@array@.isEmpty()"
-#166 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "@array@.isEmpty()"
-#167 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "@array@.isEmpty()"
-#168 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "@array@.isEmpty()"
-#169 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "@array@.isEmpty()"
-#170 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "@array@.isEmpty()"
-#171 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "@array@.isEmpty()"
-#172 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "@array@.isEmpty()"
-#173 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Array(0)" with "@array@.isEmpty()" pattern
-#174 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "Array(0)" with "@array@.isEmpty()" pattern
-#175 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "Array(0)" does not match "@array@.isEmpty()".
-#176 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@array@.isEmpty()"
-#177 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@array@.isEmpty()"
-#178 Matcher Coduo\PHPMatcher\Matcher\UlidMatcher can't match pattern "@array@.isEmpty()"
-#179 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@array@.isEmpty()"
-#180 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(0)" with "@array@.isEmpty()" pattern
-#181 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(0)" does not match "@array@.isEmpty()".
-#182 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@array@.isEmpty()"
-#183 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "Array(0)" with "@array@.isEmpty()" pattern
-#184 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "Array(0)" with "@array@.isEmpty()" pattern
-#185 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: array "Array(0)" is not a valid string.
-#186 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(0)" with "@array@.isEmpty()" pattern
-#187 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: array "Array(0)" is not a valid string.
-#188 Expander isEmpty matching value "Array(0)"
-#189 Expander isEmpty successfully matched value "Array(0)"
-#190 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(0)" with "@array@.isEmpty()" pattern
-#191 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Array(5)"
-#192 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(5)" with "Array(5)" pattern
-#193 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
-#194 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Array(5)"
-#195 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(5)" with "Array(5)" pattern
-#196 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
-#197 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
-#198 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
-#199 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Array(5)"
-#200 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Array(5)"
-#201 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Array(5)"
-#202 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Array(5)"
-#203 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Array(5)"
-#204 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Array(5)"
-#205 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Array(5)"
-#206 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Array(5)"
-#207 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Array(5)"
-#208 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can't match pattern "Array(5)"
-#209 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
-#210 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
-#211 Matcher Coduo\PHPMatcher\Matcher\UlidMatcher can't match pattern "Array(5)"
-#212 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
-#213 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(5)" with "Array(5)" pattern
-#214 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(0)" does not match "@array@.isEmpty()".
-#215 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
-#216 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(5)" with "Array(5)" pattern
-#217 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: "Array(0)" does not match "@array@.isEmpty()".
-#218 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@integer@"
-#219 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "132" with "@integer@" pattern
-#220 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
-#221 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@integer@"
-#222 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "132" with "@integer@" pattern
-#223 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
-#224 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
-#225 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
-#226 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@integer@"
-#227 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
-#228 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "132" with "@integer@" pattern
-#229 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "132" with "@integer@" pattern
-#230 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "132" with "@integer@" pattern
-#231 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "132" with "@integer@" pattern
-#232 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Michał"
-#233 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Michał" with "Michał" pattern
-#234 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Michał"
-#235 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Michał"
-#236 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Michał" with "Michał" pattern
-#237 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Michał"
-#238 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Michał"
-#239 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Michał"
-#240 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Michał"
-#241 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Michał"
-#242 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Michał"
-#243 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Michał"
-#244 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Michał"
-#245 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Michał"
-#246 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Michał"
-#247 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Michał"
-#248 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Michał"
-#249 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Michał"
-#250 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Michał" with "Michał" pattern
-#251 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Michał" with "Michał" pattern
-#252 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Michał" with "Michał" pattern
-#253 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Dąbrowski"
-#254 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Dąbrowski" with "Dąbrowski" pattern
-#255 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Dąbrowski"
-#256 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Dąbrowski"
-#257 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Dąbrowski" with "Dąbrowski" pattern
-#258 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Dąbrowski"
-#259 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Dąbrowski"
-#260 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Dąbrowski"
-#261 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Dąbrowski"
-#262 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Dąbrowski"
-#263 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Dąbrowski"
-#264 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Dąbrowski"
-#265 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Dąbrowski"
-#266 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Dąbrowski"
-#267 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Dąbrowski"
-#268 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Dąbrowski"
-#269 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Dąbrowski"
-#270 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Dąbrowski"
-#271 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
-#272 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#273 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#274 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "expr(value == true)"
-#275 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "false" with "expr(value == true)" pattern
-#276 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "expr(value == true)"
-#277 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "expr(value == true)"
-#278 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "false" with "expr(value == true)" pattern
-#279 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "expr(value == true)"
-#280 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can match pattern "expr(value == true)"
-#281 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher matching value "false" with "expr(value == true)" pattern
-#282 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher failed to match value "false" with "expr(value == true)" pattern
-#283 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher error: "expr(value == true)" expression fails for value "false".
-#284 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "expr(value == true)"
-#285 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "expr(value == true)"
-#286 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "expr(value == true)"
-#287 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "expr(value == true)"
-#288 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "expr(value == true)"
-#289 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "expr(value == true)"
-#290 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "expr(value == true)"
-#291 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "expr(value == true)"
-#292 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "expr(value == true)"
-#293 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "expr(value == true)"
-#294 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "expr(value == true)"
-#295 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "false" with "expr(value == true)" pattern
-#296 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "false" with "expr(value == true)" pattern
-#297 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "false" does not match "expr(value == true)".
-#298 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "expr(value == true)"
-#299 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "expr(value == true)"
-#300 Matcher Coduo\PHPMatcher\Matcher\UlidMatcher can't match pattern "expr(value == true)"
-#301 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "expr(value == true)"
-#302 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "false" with "expr(value == true)" pattern
-#303 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "false" does not match "expr(value == true)".
-#304 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "expr(value == true)"
-#305 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "false" with "expr(value == true)" pattern
-#306 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "false" with "expr(value == true)" pattern
-#307 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: boolean "false" is not a valid string.
-#308 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "false" with "expr(value == true)" pattern
-#309 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: boolean "false" is not a valid string.
-#310 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher failed to match value "Array(3)" with "Array(3)" pattern
-#311 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher error: Value "false" does not match pattern "expr(value == true)" at path: "[users][1][enabled]"
-#312 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#313 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher error: Value "false" does not match pattern "expr(value == true)" at path: "[users][1][enabled]"
-#314 Matcher Coduo\PHPMatcher\Matcher\XmlMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
-#315 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
-#316 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
-#317 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#318 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) error: Value "false" does not match pattern "expr(value == true)" at path: "[users][1][enabled]"
-#319 Matcher Coduo\PHPMatcher\Matcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#320 Matcher Coduo\PHPMatcher\Matcher error: Value "false" does not match pattern "expr(value == true)" at path: "[users][1][enabled]"
+#93 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@integer@"
+#94 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "@integer@"
+#95 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "@integer@"
+#96 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "@integer@"
+#97 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "@integer@"
+#98 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "@integer@"
+#99 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "@integer@"
+#100 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "@integer@"
+#101 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "@integer@"
+#102 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "131" with "@integer@" pattern
+#103 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "131" with "@integer@" pattern
+#104 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "131" does not match "@integer@".
+#105 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@integer@"
+#106 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@integer@"
+#107 Matcher Coduo\PHPMatcher\Matcher\UlidMatcher can't match pattern "@integer@"
+#108 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@integer@"
+#109 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "131" with "@integer@" pattern
+#110 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "131" does not match "@integer@".
+#111 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@integer@"
+#112 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "131" with "@integer@" pattern
+#113 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "131" with "@integer@" pattern
+#114 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: integer "131" is not a valid string.
+#115 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "131" with "@integer@" pattern
+#116 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: integer "131" is not a valid string.
+#117 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher failed to match value "Array(3)" with "Array(3)" pattern
+#118 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher error: Value "131" does not match pattern "@integer@" at path: "[users][0][id]"
+#119 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#120 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher error: Value "131" does not match pattern "@integer@" at path: "[users][0][id]"
+#121 Matcher Coduo\PHPMatcher\Matcher\XmlMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#122 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#123 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#124 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#125 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) error: Value "131" does not match pattern "@integer@" at path: "[users][0][id]"
+#126 Matcher Coduo\PHPMatcher\Matcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == true)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#127 Matcher Coduo\PHPMatcher\Matcher error: Value "131" does not match pattern "@integer@" at path: "[users][0][id]"

--- a/tests/BacktraceTest/succeed_complex_matching_expected_trace.txt
+++ b/tests/BacktraceTest/succeed_complex_matching_expected_trace.txt
@@ -90,259 +90,38 @@
 #90 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
 #91 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
 #92 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@integer@"
-#93 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
-#94 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "131" with "@integer@" pattern
-#95 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "131" with "@integer@" pattern
-#96 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "131" with "@integer@" pattern
-#97 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "131" with "@integer@" pattern
-#98 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Norbert"
-#99 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Norbert" with "Norbert" pattern
-#100 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Norbert"
-#101 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Norbert"
-#102 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Norbert" with "Norbert" pattern
-#103 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Norbert"
-#104 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Norbert"
-#105 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Norbert"
-#106 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Norbert"
-#107 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Norbert"
-#108 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Norbert"
-#109 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Norbert"
-#110 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Norbert"
-#111 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Norbert"
-#112 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Norbert"
-#113 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Norbert"
-#114 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Norbert"
-#115 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Norbert"
-#116 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Norbert" with "Norbert" pattern
-#117 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Norbert" with "Norbert" pattern
-#118 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Norbert" with "Norbert" pattern
-#119 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Orzechowicz"
-#120 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Orzechowicz" with "Orzechowicz" pattern
-#121 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Orzechowicz"
-#122 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Orzechowicz"
-#123 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Orzechowicz" with "Orzechowicz" pattern
-#124 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Orzechowicz"
-#125 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Orzechowicz"
-#126 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Orzechowicz"
-#127 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Orzechowicz"
-#128 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Orzechowicz"
-#129 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Orzechowicz"
-#130 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Orzechowicz"
-#131 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Orzechowicz"
-#132 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Orzechowicz"
-#133 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Orzechowicz"
-#134 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Orzechowicz"
-#135 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Orzechowicz"
-#136 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Orzechowicz"
-#137 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Orzechowicz" with "Orzechowicz" pattern
-#138 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#139 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Orzechowicz" with "Orzechowicz" pattern
-#140 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@boolean@"
-#141 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "true" with "@boolean@" pattern
-#142 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@boolean@"
-#143 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@boolean@"
-#144 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "true" with "@boolean@" pattern
-#145 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@boolean@"
-#146 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@boolean@"
-#147 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@boolean@"
-#148 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@boolean@"
-#149 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@boolean@"
-#150 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can match pattern "@boolean@"
-#151 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher matching value "true" with "@boolean@" pattern
-#152 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher successfully matched value "true" with "@boolean@" pattern
-#153 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "true" with "@boolean@" pattern
-#154 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "true" with "@boolean@" pattern
-#155 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@array@.isEmpty()"
-#156 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(0)" with "@array@.isEmpty()" pattern
-#157 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@array@.isEmpty()"
-#158 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@array@.isEmpty()"
-#159 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(0)" with "@array@.isEmpty()" pattern
-#160 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@array@.isEmpty()"
-#161 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@array@.isEmpty()"
-#162 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@array@.isEmpty()"
-#163 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@array@.isEmpty()"
-#164 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@array@.isEmpty()"
-#165 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "@array@.isEmpty()"
-#166 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "@array@.isEmpty()"
-#167 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "@array@.isEmpty()"
-#168 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "@array@.isEmpty()"
-#169 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "@array@.isEmpty()"
-#170 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "@array@.isEmpty()"
-#171 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "@array@.isEmpty()"
-#172 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "@array@.isEmpty()"
-#173 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Array(0)" with "@array@.isEmpty()" pattern
-#174 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "Array(0)" with "@array@.isEmpty()" pattern
-#175 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "Array(0)" does not match "@array@.isEmpty()".
-#176 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@array@.isEmpty()"
-#177 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@array@.isEmpty()"
-#178 Matcher Coduo\PHPMatcher\Matcher\UlidMatcher can't match pattern "@array@.isEmpty()"
-#179 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@array@.isEmpty()"
-#180 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(0)" with "@array@.isEmpty()" pattern
-#181 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(0)" does not match "@array@.isEmpty()".
-#182 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@array@.isEmpty()"
-#183 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "Array(0)" with "@array@.isEmpty()" pattern
-#184 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "Array(0)" with "@array@.isEmpty()" pattern
-#185 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: array "Array(0)" is not a valid string.
-#186 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(0)" with "@array@.isEmpty()" pattern
-#187 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: array "Array(0)" is not a valid string.
-#188 Expander isEmpty matching value "Array(0)"
-#189 Expander isEmpty successfully matched value "Array(0)"
-#190 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(0)" with "@array@.isEmpty()" pattern
-#191 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Array(5)"
-#192 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(5)" with "Array(5)" pattern
-#193 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Array(5)"
-#194 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Array(5)"
-#195 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(5)" with "Array(5)" pattern
-#196 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Array(5)"
-#197 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Array(5)"
-#198 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Array(5)"
-#199 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Array(5)"
-#200 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Array(5)"
-#201 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Array(5)"
-#202 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Array(5)"
-#203 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Array(5)"
-#204 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Array(5)"
-#205 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Array(5)"
-#206 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Array(5)"
-#207 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Array(5)"
-#208 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can't match pattern "Array(5)"
-#209 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "Array(5)"
-#210 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "Array(5)"
-#211 Matcher Coduo\PHPMatcher\Matcher\UlidMatcher can't match pattern "Array(5)"
-#212 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "Array(5)"
-#213 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(5)" with "Array(5)" pattern
-#214 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(0)" does not match "@array@.isEmpty()".
-#215 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "Array(5)"
-#216 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(5)" with "Array(5)" pattern
-#217 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: "Array(0)" does not match "@array@.isEmpty()".
-#218 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@integer@"
-#219 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "132" with "@integer@" pattern
-#220 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@integer@"
-#221 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@integer@"
-#222 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "132" with "@integer@" pattern
-#223 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@integer@"
-#224 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@integer@"
-#225 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@integer@"
-#226 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@integer@"
-#227 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can match pattern "@integer@"
-#228 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher matching value "132" with "@integer@" pattern
-#229 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher successfully matched value "132" with "@integer@" pattern
-#230 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "132" with "@integer@" pattern
-#231 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "132" with "@integer@" pattern
-#232 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Michał"
-#233 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Michał" with "Michał" pattern
-#234 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Michał"
-#235 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Michał"
-#236 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Michał" with "Michał" pattern
-#237 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Michał"
-#238 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Michał"
-#239 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Michał"
-#240 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Michał"
-#241 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Michał"
-#242 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Michał"
-#243 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Michał"
-#244 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Michał"
-#245 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Michał"
-#246 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Michał"
-#247 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Michał"
-#248 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Michał"
-#249 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Michał"
-#250 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Michał" with "Michał" pattern
-#251 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Michał" with "Michał" pattern
-#252 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Michał" with "Michał" pattern
-#253 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "Dąbrowski"
-#254 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Dąbrowski" with "Dąbrowski" pattern
-#255 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "Dąbrowski"
-#256 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "Dąbrowski"
-#257 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Dąbrowski" with "Dąbrowski" pattern
-#258 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "Dąbrowski"
-#259 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "Dąbrowski"
-#260 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "Dąbrowski"
-#261 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "Dąbrowski"
-#262 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "Dąbrowski"
-#263 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "Dąbrowski"
-#264 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "Dąbrowski"
-#265 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "Dąbrowski"
-#266 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "Dąbrowski"
-#267 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "Dąbrowski"
-#268 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "Dąbrowski"
-#269 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "Dąbrowski"
-#270 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "Dąbrowski"
-#271 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Dąbrowski" with "Dąbrowski" pattern
-#272 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#273 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "Dąbrowski" with "Dąbrowski" pattern
-#274 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "expr(value == false)"
-#275 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "false" with "expr(value == false)" pattern
-#276 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "expr(value == false)"
-#277 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "expr(value == false)"
-#278 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "false" with "expr(value == false)" pattern
-#279 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "expr(value == false)"
-#280 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can match pattern "expr(value == false)"
-#281 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher matching value "false" with "expr(value == false)" pattern
-#282 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher successfully matched value "false" with "expr(value == false)" pattern
-#283 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "false" with "expr(value == false)" pattern
-#284 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "false" with "expr(value == false)" pattern
-#285 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@array@"
-#286 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "Array(1)" with "@array@" pattern
-#287 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@array@"
-#288 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@array@"
-#289 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "Array(1)" with "@array@" pattern
-#290 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@array@"
-#291 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@array@"
-#292 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@array@"
-#293 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can't match pattern "@array@"
-#294 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@array@"
-#295 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "@array@"
-#296 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "@array@"
-#297 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "@array@"
-#298 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "@array@"
-#299 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "@array@"
-#300 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "@array@"
-#301 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "@array@"
-#302 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "@array@"
-#303 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "Array(1)" with "@array@" pattern
-#304 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "Array(1)" with "@array@" pattern
-#305 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "Array(1)" does not match "@array@".
-#306 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@array@"
-#307 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@array@"
-#308 Matcher Coduo\PHPMatcher\Matcher\UlidMatcher can't match pattern "@array@"
-#309 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@array@"
-#310 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "Array(1)" with "@array@" pattern
-#311 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "Array(1)" does not match "@array@".
-#312 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@array@"
-#313 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "Array(1)" with "@array@" pattern
-#314 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "Array(1)" with "@array@" pattern
-#315 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: array "Array(1)" is not a valid string.
-#316 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "Array(1)" with "@array@" pattern
-#317 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: array "Array(1)" is not a valid string.
-#318 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(1)" with "@array@" pattern
-#319 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@string@"
-#320 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
-#321 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@string@"
-#322 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@string@"
-#323 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
-#324 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
-#325 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
-#326 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
-#327 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
-#328 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "http://example.com/api/users/1?limit=2" with "@string@" pattern
-#329 Matcher Coduo\PHPMatcher\Matcher\StringMatcher successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
-#330 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
-#331 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "http://example.com/api/users/1?limit=2" with "@string@" pattern
-#332 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) can match pattern "@string@"
-#333 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
-#334 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "@string@"
-#335 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) can match pattern "@string@"
-#336 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
-#337 Matcher Coduo\PHPMatcher\Matcher\CallbackMatcher can't match pattern "@string@"
-#338 Matcher Coduo\PHPMatcher\Matcher\ExpressionMatcher can't match pattern "@string@"
-#339 Matcher Coduo\PHPMatcher\Matcher\NullMatcher can't match pattern "@string@"
-#340 Matcher Coduo\PHPMatcher\Matcher\StringMatcher can match pattern "@string@"
-#341 Matcher Coduo\PHPMatcher\Matcher\StringMatcher matching value "http://example.com/api/users/3?limit=2" with "@string@" pattern
-#342 Matcher Coduo\PHPMatcher\Matcher\StringMatcher successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
-#343 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
-#344 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) successfully matched value "http://example.com/api/users/3?limit=2" with "@string@" pattern
-#345 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher successfully matched value "Array(3)" with "Array(3)" pattern
-#346 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#347 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
-#348 Matcher Coduo\PHPMatcher\Matcher successfully matched value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#93 Matcher Coduo\PHPMatcher\Matcher\IntegerMatcher can't match pattern "@integer@"
+#94 Matcher Coduo\PHPMatcher\Matcher\BooleanMatcher can't match pattern "@integer@"
+#95 Matcher Coduo\PHPMatcher\Matcher\DoubleMatcher can't match pattern "@integer@"
+#96 Matcher Coduo\PHPMatcher\Matcher\NumberMatcher can't match pattern "@integer@"
+#97 Matcher Coduo\PHPMatcher\Matcher\TimeMatcher can't match pattern "@integer@"
+#98 Matcher Coduo\PHPMatcher\Matcher\DateMatcher can't match pattern "@integer@"
+#99 Matcher Coduo\PHPMatcher\Matcher\DateTimeMatcher can't match pattern "@integer@"
+#100 Matcher Coduo\PHPMatcher\Matcher\TimeZoneMatcher can't match pattern "@integer@"
+#101 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher can match pattern "@integer@"
+#102 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher matching value "131" with "@integer@" pattern
+#103 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher failed to match value "131" with "@integer@" pattern
+#104 Matcher Coduo\PHPMatcher\Matcher\ScalarMatcher error: "131" does not match "@integer@".
+#105 Matcher Coduo\PHPMatcher\Matcher\WildcardMatcher can't match pattern "@integer@"
+#106 Matcher Coduo\PHPMatcher\Matcher\UuidMatcher can't match pattern "@integer@"
+#107 Matcher Coduo\PHPMatcher\Matcher\UlidMatcher can't match pattern "@integer@"
+#108 Matcher Coduo\PHPMatcher\Matcher\JsonObjectMatcher can't match pattern "@integer@"
+#109 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) failed to match value "131" with "@integer@" pattern
+#110 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (scalars) error: "131" does not match "@integer@".
+#111 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can match pattern "@integer@"
+#112 Matcher Coduo\PHPMatcher\Matcher\TextMatcher matching value "131" with "@integer@" pattern
+#113 Matcher Coduo\PHPMatcher\Matcher\TextMatcher failed to match value "131" with "@integer@" pattern
+#114 Matcher Coduo\PHPMatcher\Matcher\TextMatcher error: integer "131" is not a valid string.
+#115 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) failed to match value "131" with "@integer@" pattern
+#116 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (array) error: integer "131" is not a valid string.
+#117 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher failed to match value "Array(3)" with "Array(3)" pattern
+#118 Matcher Coduo\PHPMatcher\Matcher\ArrayMatcher error: Value "131" does not match pattern "@integer@" at path: "[users][0][id]"
+#119 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#120 Matcher Coduo\PHPMatcher\Matcher\JsonMatcher error: Value "131" does not match pattern "@integer@" at path: "[users][0][id]"
+#121 Matcher Coduo\PHPMatcher\Matcher\XmlMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#122 Matcher Coduo\PHPMatcher\Matcher\OrMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#123 Matcher Coduo\PHPMatcher\Matcher\TextMatcher can't match pattern "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}"
+#124 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#125 Matcher Coduo\PHPMatcher\Matcher\ChainMatcher (all) error: Value "131" does not match pattern "@integer@" at path: "[users][0][id]"
+#126 Matcher Coduo\PHPMatcher\Matcher failed to match value "{"users":[{"id":131,"firstName":"Norbert","lastName":"Orzechowicz","enabled":true,"roles":[]},{"id":132,"firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":false,"roles":["ROLE_DEVELOPER"]}],"prevPage":"http:\/\/example.com\/api\/users\/1?limit=2","nextPage":"http:\/\/example.com\/api\/users\/3?limit=2"}" with "{"users":[{"id":"@integer@","firstName":"Norbert","lastName":"Orzechowicz","enabled":"@boolean@","roles":"@array@.isEmpty()"},{"id":"@integer@","firstName":"Micha\u0142","lastName":"D\u0105browski","enabled":"expr(value == false)","roles":"@array@"}],"prevPage":"@string@","nextPage":"@string@"}" pattern
+#127 Matcher Coduo\PHPMatcher\Matcher error: Value "131" does not match pattern "@integer@" at path: "[users][0][id]"

--- a/tests/Matcher/Pattern/Expander/BeforeTest.php
+++ b/tests/Matcher/Pattern/Expander/BeforeTest.php
@@ -10,38 +10,54 @@ use PHPUnit\Framework\TestCase;
 
 class BeforeTest extends TestCase
 {
-    public static function examplesProvider()
+    public static function examplesProvider() : array
     {
         return [
-            ['+2 day', 'today', true],
-            ['2018-02-06T04:20:33', '2017-02-06T04:20:33', true],
-            ['2017-02-06T04:20:33', '2018-02-06T04:20:33', false],
+            ['+2 day', 'today'],
+            ['2018-02-06T04:20:33', '2017-02-06T04:20:33'],
+            ['2017-02-06T04:20:33', '2018-02-06T04:20:33', 'Value "2018-02-06T04:20:33" is after or equal to "2017-02-06T04:20:33+00:00".'],
+            ['2024-04-21', '2024-04-21', 'Value "2024-04-21" is after or equal to "2024-04-21T00:00:00+00:00".'],
+            ['10:00:00', '00:01:00'],
+            ['10:00:00', '00:01:00'],
+            ['10:00:00.123456', '10:00:00.000000'],
+            ['10:00:00.123456', '10:00:00.123457', 'Value "10:00:00.123457" is after or equal to "@date@T10:00:00+00:00".'],
+            ['10:30', '00:08:00'],
+            ['8:30', '8:29'],
+            ['10:00:00', '10:00:00', 'Value "10:00:00" is after or equal to "@date@T10:00:00+00:00".'],
+            ['10:00:00', '10:00:01', 'Value "10:00:01" is after or equal to "@date@T10:00:00+00:00".'],
         ];
     }
 
-    public static function invalidCasesProvider()
+    public static function invalidCasesProvider() : array
     {
         return [
-            ['today', 'ipsum lorem', 'Value "ipsum lorem" is not a valid date.'],
-            ['2017-02-06T04:20:33', 'ipsum lorem', 'Value "ipsum lorem" is not a valid date.'],
-            ['today', 5, 'Before expander require "string", got "5".'],
+            ['today', 'ipsum lorem', 'Value "ipsum lorem" is not a valid date, date time or time.'],
+            ['2017-02-06T04:20:33', 'ipsum lorem', 'Value "ipsum lorem" is not a valid date, date time or time.'],
+            ['today', 5, 'before expander require "string", got "5".'],
+            ['03:00', '99:88:77', 'Value "99:88:77" is not a valid date, date time or time.'],
         ];
     }
 
     /**
      * @dataProvider examplesProvider
      */
-    public function test_examples($boundary, $value, $expectedResult) : void
+    public function test_examples(string $boundary, string $value, ?string $expectedError = null) : void
     {
         $expander = new Before($boundary);
         $expander->setBacktrace(new Backtrace\InMemoryBacktrace());
-        $this->assertEquals($expectedResult, $expander->match($value));
+        $this->assertEquals($expectedError === null, $expander->match($value));
+
+        if (\is_string($expectedError)) {
+            $expectedError = \str_replace('@date@', (new \DateTime())->format('Y-m-d'), $expectedError);
+        }
+
+        $this->assertEquals($expectedError, $expander->getError());
     }
 
     /**
      * @dataProvider invalidCasesProvider
      */
-    public function test_error_when_matching_fail($boundary, $value, $errorMessage) : void
+    public function test_error_when_matching_fail(string $boundary, mixed $value, string $errorMessage) : void
     {
         $expander = new Before($boundary);
         $expander->setBacktrace(new Backtrace\InMemoryBacktrace());


### PR DESCRIPTION




<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Test coverage of both expanders</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Error handling of after/before expanders when value was equal to boundary</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Moved much of the code into an abstract class</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Explicit handling of Time</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Hi,

I encountered a bug trying to use the after/before expanders when it wouldn't match because the value was equals to the boundary.
No error was set by the expander, which would result to a type error in DateMatcher line 54 (matcherFailed method expected a string as its 4th parameter and null was given)

```php
$this->backtrace->matcherFailed(self::class, $value, $pattern, $this->error);
```

While trying to fix it I saw that the explicit handling of Time was never reached because in the constructor it first checks if the boundary is a DateTime and any Time will be a valid DateTime as we can see in the Time::fromString method

```php
$this->boundaryDateTime = DateTime::fromString($boundary);
```

I added tests to increase the coverage of the expanders and removed any explicit handling of Time.

Finally, given how similar the expanders were I created an abstract class to remove the code duplication I hope that's fine by you.

Please tell me if I missed something and thank you for this much needed library!