### PR TITLE
Fix matching for '@array@||@null@'

### DIFF
--- a/src/Factory/MatcherFactory.php
+++ b/src/Factory/MatcherFactory.php
@@ -49,14 +49,12 @@ final class MatcherFactory implements Factory
 
     private function buildArrayMatcher(Matcher\ChainMatcher $scalarMatchers, Parser $parser, Backtrace $backtrace) : Matcher\ArrayMatcher
     {
-        $orMatcher = new Matcher\OrMatcher($backtrace, $scalarMatchers);
-
-        return new Matcher\ArrayMatcher(
+        $arrayMatcher = new Matcher\ArrayMatcher(
             new Matcher\ChainMatcher(
                 'array',
                 $backtrace,
                 [
-                    $orMatcher,
+                    new Matcher\OrMatcher($backtrace, $orMatchers = clone $scalarMatchers),
                     $scalarMatchers,
                     new Matcher\TextMatcher($backtrace, $parser),
                 ]
@@ -64,6 +62,9 @@ final class MatcherFactory implements Factory
             $backtrace,
             $parser
         );
+        $orMatchers->registerMatcher($arrayMatcher);
+
+        return $arrayMatcher;
     }
 
     private function buildScalarMatchers(Parser $parser, Backtrace $backtrace) : Matcher\ChainMatcher

--- a/src/Matcher/ChainMatcher.php
+++ b/src/Matcher/ChainMatcher.php
@@ -36,6 +36,11 @@ final class ChainMatcher extends Matcher
         $this->name = $name;
     }
 
+    public function registerMatcher(ValueMatcher $matcher) : void
+    {
+        $this->matchers[] = $matcher;
+    }
+
     public function match($value, $pattern) : bool
     {
         $this->backtrace->matcherEntrance($this->matcherName(), $value, $pattern);

--- a/tests/Matcher/OrMatcherTest.php
+++ b/tests/Matcher/OrMatcherTest.php
@@ -67,6 +67,14 @@ class OrMatcherTest extends TestCase
             ],
             [
                 [
+                    'test' => [],
+                ],
+                [
+                    'test' => '@array@||@null@',
+                ],
+            ],
+            [
+                [
                     'first_level' => ['second_level', ['third_level']],
                 ],
                 '@array@||@null@||@*@',


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
    <li>Fix #471 </li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
This PR fixes #471 by making aware the "OrMatcher" about the "ArrayMatcher".